### PR TITLE
Fix exam question shuffling to use proper Fisher-Yates algorithm

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -1062,8 +1062,8 @@
 
         // Start final exam
         function startFinalExam() {
-            // Shuffle all questions
-            state.examQuestions = [...questions].sort(() => Math.random() - 0.5);
+            // Shuffle all questions using Fisher-Yates
+            state.examQuestions = shuffleArray([...questions]);
             state.examIndex = 0;
             state.examCorrect = 0;
             state.currentMode = 'exam';


### PR DESCRIPTION
The previous .sort(() => Math.random() - 0.5) method was biased and didn't provide truly random shuffling. Now uses the same shuffleArray function used for randomizing answer choices.