### PR TITLE
Add server-side progress storage

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -842,27 +842,45 @@
             claimedKnowledge: false
         };
 
-        // Load state from localStorage
-        function loadState() {
-            const saved = localStorage.getItem('wgu-quiz-state');
-            if (saved) {
-                const parsed = JSON.parse(saved);
-                state.mastered = parsed.mastered || [];
-                state.streaks = parsed.streaks || {};
-                state.totalCorrect = parsed.totalCorrect || 0;
-                state.totalAnswered = parsed.totalAnswered || 0;
+        const STORAGE_URL = 'https://quiz-storage.kvquiz.workers.dev';
+
+        // Load state from server
+        async function loadState() {
+            try {
+                const res = await fetch(STORAGE_URL);
+                if (res.ok) {
+                    const data = await res.json();
+                    state.mastered = data.mastered || [];
+                    state.streaks = data.streaks || {};
+                    state.totalCorrect = data.totalCorrect || 0;
+                    state.totalAnswered = data.totalAnswered || 0;
+                }
+            } catch (e) {
+                console.log('Could not load from server');
             }
             updateStats();
         }
 
-        // Save state to localStorage
+        // Save state to server
+        let saveTimeout = null;
         function saveState() {
-            localStorage.setItem('wgu-quiz-state', JSON.stringify({
-                mastered: state.mastered,
-                streaks: state.streaks,
-                totalCorrect: state.totalCorrect,
-                totalAnswered: state.totalAnswered
-            }));
+            clearTimeout(saveTimeout);
+            saveTimeout = setTimeout(async () => {
+                try {
+                    await fetch(STORAGE_URL, {
+                        method: 'PUT',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            mastered: state.mastered,
+                            streaks: state.streaks,
+                            totalCorrect: state.totalCorrect,
+                            totalAnswered: state.totalAnswered
+                        })
+                    });
+                } catch (e) {
+                    console.log('Could not save to server');
+                }
+            }, 500);
         }
 
         // Update stats display

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1,0 +1,26 @@
+export default {
+  async fetch(request, env) {
+    const headers = {
+      'Access-Control-Allow-Origin': 'https://fullstackkevinvandriel.github.io',
+      'Access-Control-Allow-Methods': 'GET, PUT, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Content-Type': 'application/json'
+    };
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers });
+    }
+
+    if (request.method === 'GET') {
+      const data = await env.PROGRESS.get('state');
+      return new Response(data || '{}', { headers });
+    }
+
+    if (request.method === 'PUT') {
+      await env.PROGRESS.put('state', await request.text());
+      return new Response('{"ok":true}', { headers });
+    }
+
+    return new Response('{"error":"not found"}', { status: 404, headers });
+  }
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,7 @@
+name = "quiz-storage"
+main = "worker.js"
+compatibility_date = "2024-01-01"
+
+[[kv_namespaces]]
+binding = "PROGRESS"
+id = "a4c72e54d0c448feae651095719e5095"


### PR DESCRIPTION
## Summary
- Deployed Cloudflare Worker at https://quiz-storage.kvquiz.workers.dev
- Quiz now saves/loads progress from server instead of localStorage
- Progress syncs across all devices

## Changes
- `quiz.html`: Updated to use server storage
- `worker/worker.js`: Simple KV storage worker
- `worker/wrangler.toml`: Cloudflare config