### PR TITLE
feat: add quiz data import with drag/drop and multi-format parsing

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -418,6 +418,111 @@
             font-weight: bold;
         }
 
+        /* Import Drop Zone */
+        .drop-zone {
+            border: 2px dashed #4fc3f7;
+            border-radius: 10px;
+            padding: 40px 20px;
+            text-align: center;
+            cursor: pointer;
+            transition: all 0.2s;
+            margin-bottom: 20px;
+        }
+
+        .drop-zone:hover, .drop-zone.drag-over {
+            background: rgba(79, 195, 247, 0.1);
+            border-color: #81d4fa;
+        }
+
+        .drop-zone-icon {
+            font-size: 3rem;
+            margin-bottom: 10px;
+        }
+
+        .drop-zone-text {
+            color: #888;
+            margin-bottom: 5px;
+        }
+
+        .drop-zone-subtext {
+            color: #666;
+            font-size: 0.85rem;
+        }
+
+        .import-textarea {
+            width: 100%;
+            min-height: 150px;
+            background: #0f3460;
+            border: 1px solid #333;
+            border-radius: 8px;
+            color: #eaeaea;
+            padding: 15px;
+            font-family: monospace;
+            font-size: 0.9rem;
+            resize: vertical;
+            margin-bottom: 15px;
+        }
+
+        .import-textarea:focus {
+            outline: none;
+            border-color: #4fc3f7;
+        }
+
+        .import-preview {
+            background: #0f3460;
+            border-radius: 8px;
+            padding: 15px;
+            margin-top: 15px;
+            max-height: 200px;
+            overflow-y: auto;
+        }
+
+        .import-preview-item {
+            padding: 8px 0;
+            border-bottom: 1px solid #333;
+        }
+
+        .import-preview-item:last-child {
+            border-bottom: none;
+        }
+
+        .import-stats {
+            display: flex;
+            gap: 20px;
+            margin-bottom: 15px;
+            color: #888;
+        }
+
+        .import-stats span {
+            color: #4fc3f7;
+            font-weight: bold;
+        }
+
+        .format-tabs {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 15px;
+        }
+
+        .format-tab {
+            padding: 8px 16px;
+            background: #0f3460;
+            border: none;
+            border-radius: 5px;
+            color: #888;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .format-tab:hover {
+            color: #eaeaea;
+        }
+
+        .format-tab.active {
+            background: #4fc3f7;
+            color: #1a1a2e;
+        }
+
         .help-btn {
             background: none;
             border: 2px solid #4fc3f7;
@@ -550,6 +655,7 @@
             <button class="btn" onclick="startFinalExam()">Final Exam (100% Required)</button>
             <button class="btn" onclick="showProgress()">View Progress</button>
             <button class="btn" onclick="showMasteredList()">Manage Mastered Questions</button>
+            <button class="btn btn-success btn-small" onclick="showImportModal()">Import Quiz Data</button>
             <button class="btn btn-danger btn-small" onclick="resetProgress()">Reset All Progress</button>
             <button class="btn btn-small" onclick="changeKeyword()" style="margin-top: 10px; opacity: 0.7;">Change Keyword</button>
         </div>
@@ -642,6 +748,66 @@
                 <button class="modal-close" onclick="closeStudyMaterial()">&times;</button>
             </div>
             <div class="modal-body" id="modal-body">
+            </div>
+        </div>
+    </div>
+
+    <!-- Import Quiz Modal -->
+    <div id="import-modal" class="modal-overlay hidden" onclick="closeImportModalOnOverlay(event)">
+        <div class="modal-content" onclick="event.stopPropagation()" style="max-width: 600px;">
+            <div class="modal-header">
+                <h2>Import Quiz Data</h2>
+                <button class="modal-close" onclick="closeImportModal()">&times;</button>
+            </div>
+            <div class="modal-body">
+                <!-- Drop Zone -->
+                <div class="drop-zone" id="drop-zone" onclick="document.getElementById('file-input').click()">
+                    <div class="drop-zone-icon">📁</div>
+                    <div class="drop-zone-text">Drop a file here or click to browse</div>
+                    <div class="drop-zone-subtext">Supports JSON, CSV, or TXT files</div>
+                    <input type="file" id="file-input" accept=".json,.csv,.txt" style="display: none;" onchange="handleFileSelect(event)">
+                </div>
+
+                <!-- Or paste text -->
+                <p style="text-align: center; color: #666; margin-bottom: 15px;">— or paste text directly —</p>
+
+                <textarea id="import-textarea" class="import-textarea" placeholder="Paste your quiz data here...
+
+Supported formats:
+
+JSON:
+[{&quot;q&quot;: &quot;Question?&quot;, &quot;a&quot;: &quot;Answer&quot;, &quot;choices&quot;: [&quot;A&quot;,&quot;B&quot;,&quot;C&quot;,&quot;D&quot;], &quot;correct&quot;: 0}]
+
+Q&amp;A Format:
+Q: What is the capital of France?
+A: Paris
+
+CSV:
+question,answer,choice1,choice2,choice3,choice4,correct
+&quot;Question?&quot;,&quot;Answer&quot;,&quot;A&quot;,&quot;B&quot;,&quot;C&quot;,&quot;D&quot;,0"></textarea>
+
+                <!-- Preview Section -->
+                <div id="import-preview-section" style="display: none;">
+                    <div class="import-stats">
+                        <div>Questions found: <span id="import-count">0</span></div>
+                        <div>Format: <span id="import-format">Unknown</span></div>
+                    </div>
+                    <div class="import-preview" id="import-preview"></div>
+                </div>
+
+                <!-- Action Buttons -->
+                <div class="btn-group" style="margin-top: 20px;">
+                    <button class="btn" onclick="parseImportData()">Preview Import</button>
+                    <button class="btn btn-primary" id="import-confirm-btn" onclick="confirmImport()" disabled>Import Questions</button>
+                </div>
+
+                <!-- Import Options -->
+                <div style="margin-top: 15px; padding-top: 15px; border-top: 1px solid #333;">
+                    <label style="display: flex; align-items: center; gap: 10px; color: #888; cursor: pointer;">
+                        <input type="checkbox" id="import-replace" style="width: 18px; height: 18px;">
+                        Replace existing questions (instead of adding to them)
+                    </label>
+                </div>
             </div>
         </div>
     </div>
@@ -1921,9 +2087,333 @@
             }
         }
 
+        // ========== IMPORT FUNCTIONALITY ==========
+        let parsedImportData = [];
+
+        function showImportModal() {
+            document.getElementById('import-modal').classList.remove('hidden');
+            document.body.style.overflow = 'hidden';
+            // Reset state
+            document.getElementById('import-textarea').value = '';
+            document.getElementById('import-preview-section').style.display = 'none';
+            document.getElementById('import-confirm-btn').disabled = true;
+            parsedImportData = [];
+            setupDropZone();
+        }
+
+        function closeImportModal() {
+            document.getElementById('import-modal').classList.add('hidden');
+            document.body.style.overflow = '';
+        }
+
+        function closeImportModalOnOverlay(event) {
+            if (event.target === document.getElementById('import-modal')) {
+                closeImportModal();
+            }
+        }
+
+        function setupDropZone() {
+            const dropZone = document.getElementById('drop-zone');
+
+            ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+                dropZone.addEventListener(eventName, preventDefaults, false);
+            });
+
+            function preventDefaults(e) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+
+            ['dragenter', 'dragover'].forEach(eventName => {
+                dropZone.addEventListener(eventName, () => dropZone.classList.add('drag-over'), false);
+            });
+
+            ['dragleave', 'drop'].forEach(eventName => {
+                dropZone.addEventListener(eventName, () => dropZone.classList.remove('drag-over'), false);
+            });
+
+            dropZone.addEventListener('drop', handleDrop, false);
+        }
+
+        function handleDrop(e) {
+            const files = e.dataTransfer.files;
+            if (files.length > 0) {
+                handleFile(files[0]);
+            }
+        }
+
+        function handleFileSelect(event) {
+            const file = event.target.files[0];
+            if (file) {
+                handleFile(file);
+            }
+        }
+
+        function handleFile(file) {
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                document.getElementById('import-textarea').value = e.target.result;
+                parseImportData();
+            };
+            reader.readAsText(file);
+        }
+
+        function parseImportData() {
+            const text = document.getElementById('import-textarea').value.trim();
+            if (!text) {
+                alert('Please enter or paste some data to import.');
+                return;
+            }
+
+            let result = { questions: [], format: 'Unknown' };
+
+            // Try JSON first
+            result = tryParseJSON(text);
+
+            // Try CSV if JSON failed
+            if (result.questions.length === 0) {
+                result = tryParseCSV(text);
+            }
+
+            // Try Q&A text format
+            if (result.questions.length === 0) {
+                result = tryParseQAText(text);
+            }
+
+            // Try simple line-by-line (flashcard style)
+            if (result.questions.length === 0) {
+                result = tryParseFlashcards(text);
+            }
+
+            parsedImportData = result.questions;
+            showImportPreview(result);
+        }
+
+        function tryParseJSON(text) {
+            try {
+                const data = JSON.parse(text);
+                const arr = Array.isArray(data) ? data : [data];
+                const questions = arr.map((item, idx) => normalizeQuestion(item, idx)).filter(q => q !== null);
+                return { questions, format: 'JSON' };
+            } catch (e) {
+                return { questions: [], format: 'Unknown' };
+            }
+        }
+
+        function tryParseCSV(text) {
+            const lines = text.split('\n').map(l => l.trim()).filter(l => l);
+            if (lines.length < 2) return { questions: [], format: 'Unknown' };
+
+            // Check if first line looks like a header
+            const firstLine = lines[0].toLowerCase();
+            const hasHeader = firstLine.includes('question') || firstLine.includes('q,') || firstLine.includes('"q"');
+
+            const dataLines = hasHeader ? lines.slice(1) : lines;
+            const questions = [];
+
+            for (let i = 0; i < dataLines.length; i++) {
+                const parsed = parseCSVLine(dataLines[i]);
+                if (parsed.length >= 2) {
+                    const q = {
+                        id: questions.length + 1,
+                        category: 'Imported',
+                        q: parsed[0],
+                        a: parsed[1],
+                        choices: parsed.length >= 6 ? [parsed[2], parsed[3], parsed[4], parsed[5]] : generateChoices(parsed[1]),
+                        correct: parsed.length >= 7 ? parseInt(parsed[6]) || 0 : 0
+                    };
+                    questions.push(q);
+                }
+            }
+
+            return { questions, format: questions.length > 0 ? 'CSV' : 'Unknown' };
+        }
+
+        function parseCSVLine(line) {
+            const result = [];
+            let current = '';
+            let inQuotes = false;
+
+            for (let i = 0; i < line.length; i++) {
+                const char = line[i];
+                if (char === '"') {
+                    inQuotes = !inQuotes;
+                } else if (char === ',' && !inQuotes) {
+                    result.push(current.trim());
+                    current = '';
+                } else {
+                    current += char;
+                }
+            }
+            result.push(current.trim());
+            return result;
+        }
+
+        function tryParseQAText(text) {
+            const questions = [];
+            // Match Q: ... A: ... patterns
+            const qaPattern = /Q:\s*(.+?)[\n\r]+A:\s*(.+?)(?=[\n\r]+Q:|$)/gis;
+            let match;
+
+            while ((match = qaPattern.exec(text)) !== null) {
+                const q = {
+                    id: questions.length + 1,
+                    category: 'Imported',
+                    q: match[1].trim(),
+                    a: match[2].trim(),
+                    choices: generateChoices(match[2].trim()),
+                    correct: 0
+                };
+                questions.push(q);
+            }
+
+            return { questions, format: questions.length > 0 ? 'Q&A Text' : 'Unknown' };
+        }
+
+        function tryParseFlashcards(text) {
+            const questions = [];
+            const lines = text.split('\n').map(l => l.trim()).filter(l => l);
+
+            // Look for patterns like "term: definition" or "term - definition"
+            for (const line of lines) {
+                let parts = null;
+                if (line.includes(':')) {
+                    parts = line.split(':').map(p => p.trim());
+                } else if (line.includes(' - ')) {
+                    parts = line.split(' - ').map(p => p.trim());
+                } else if (line.includes('\t')) {
+                    parts = line.split('\t').map(p => p.trim());
+                }
+
+                if (parts && parts.length >= 2 && parts[0] && parts[1]) {
+                    const q = {
+                        id: questions.length + 1,
+                        category: 'Imported',
+                        q: parts[0].endsWith('?') ? parts[0] : `What is ${parts[0]}?`,
+                        a: parts[1],
+                        choices: generateChoices(parts[1]),
+                        correct: 0
+                    };
+                    questions.push(q);
+                }
+            }
+
+            return { questions, format: questions.length > 0 ? 'Flashcards' : 'Unknown' };
+        }
+
+        function normalizeQuestion(item, idx) {
+            // Handle various JSON formats
+            const q = item.q || item.question || item.Q || item.Question;
+            const a = item.a || item.answer || item.A || item.Answer;
+
+            if (!q) return null;
+
+            let choices = item.choices || item.options || item.Options;
+            let correct = item.correct ?? item.correctIndex ?? item.answer_index ?? 0;
+
+            if (!choices || !Array.isArray(choices) || choices.length < 2) {
+                choices = generateChoices(a || '');
+                correct = 0;
+            }
+
+            return {
+                id: idx + 1,
+                category: item.category || item.Category || 'Imported',
+                q: q,
+                a: a || choices[correct] || '',
+                choices: choices,
+                correct: correct
+            };
+        }
+
+        function generateChoices(answer) {
+            // For Q&A without choices, generate placeholder choices
+            return [
+                answer,
+                'Alternative answer 1',
+                'Alternative answer 2',
+                'Alternative answer 3'
+            ];
+        }
+
+        function showImportPreview(result) {
+            const previewSection = document.getElementById('import-preview-section');
+            const previewContainer = document.getElementById('import-preview');
+            const countEl = document.getElementById('import-count');
+            const formatEl = document.getElementById('import-format');
+            const confirmBtn = document.getElementById('import-confirm-btn');
+
+            countEl.textContent = result.questions.length;
+            formatEl.textContent = result.format;
+
+            if (result.questions.length === 0) {
+                previewContainer.innerHTML = '<p style="color: #e94560;">Could not parse any questions. Please check the format.</p>';
+                confirmBtn.disabled = true;
+            } else {
+                const preview = result.questions.slice(0, 5).map((q, i) => `
+                    <div class="import-preview-item">
+                        <strong style="color: #4fc3f7;">${i + 1}.</strong> ${escapeHtml(q.q.substring(0, 100))}${q.q.length > 100 ? '...' : ''}
+                    </div>
+                `).join('');
+
+                const moreText = result.questions.length > 5
+                    ? `<p style="color: #888; margin-top: 10px;">...and ${result.questions.length - 5} more questions</p>`
+                    : '';
+
+                previewContainer.innerHTML = preview + moreText;
+                confirmBtn.disabled = false;
+            }
+
+            previewSection.style.display = 'block';
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function confirmImport() {
+            if (parsedImportData.length === 0) {
+                alert('No questions to import.');
+                return;
+            }
+
+            const replaceMode = document.getElementById('import-replace').checked;
+
+            if (replaceMode) {
+                // Replace all questions
+                questions.length = 0;
+                parsedImportData.forEach((q, idx) => {
+                    q.id = idx + 1;
+                    questions.push(q);
+                });
+                // Reset progress since questions changed
+                state.mastered = [];
+                state.answerCounts = {};
+                state.totalCorrect = 0;
+                state.totalAnswered = 0;
+            } else {
+                // Add to existing questions
+                const startId = questions.length > 0 ? Math.max(...questions.map(q => q.id)) + 1 : 1;
+                parsedImportData.forEach((q, idx) => {
+                    q.id = startId + idx;
+                    questions.push(q);
+                });
+            }
+
+            // Update UI
+            updateStats();
+            saveState();
+            closeImportModal();
+
+            alert(`Successfully imported ${parsedImportData.length} questions!${replaceMode ? ' Progress has been reset.' : ''}`);
+        }
+
         document.addEventListener('keydown', function(event) {
             if (event.key === 'Escape') {
                 closeStudyMaterial();
+                closeImportModal();
             }
         });
 


### PR DESCRIPTION
## Summary
- Add "Import Quiz Data" button to main menu
- Create import modal with drag/drop file zone and paste textarea
- Implement auto-detecting parser supporting JSON, CSV, Q&A text, and flashcard formats
- Add preview before import with replace/add option

## Test plan
- [ ] Open quiz, click "Import Quiz Data"
- [ ] Test drag/drop with JSON file
- [ ] Test paste with Q&A format text
- [ ] Verify preview shows parsed questions
- [ ] Import and verify questions appear in quiz

🤖 Generated with [Claude Code](https://claude.com/claude-code)