### PR TITLE
UX: Add visible Sign Out button

### DIFF
--- a/index.html
+++ b/index.html
@@ -761,7 +761,10 @@
 
         <!-- Main Menu -->
         <div id="menu-screen" class="menu hidden">
-            <div id="current-keyword" style="text-align: center; margin-bottom: 15px; color: #888; font-size: 14px;"></div>
+            <div id="current-keyword-bar" style="display: flex; justify-content: space-between; align-items: center; background: #1a1a2e; padding: 10px 15px; border-radius: 8px; margin-bottom: 15px;">
+                <span id="current-keyword" style="color: #888; font-size: 14px;"></span>
+                <button onclick="changeKeyword()" style="background: none; border: 1px solid #666; color: #888; padding: 5px 12px; border-radius: 4px; cursor: pointer; font-size: 12px;">Sign Out</button>
+            </div>
 
             <!-- Pro Status Banner -->
             <div id="upgrade-banner" class="upgrade-banner">
@@ -781,7 +784,6 @@
             <button class="btn" onclick="showMasteredList()">Manage Mastered Questions</button>
             <button class="btn btn-success btn-small" onclick="showImportModal()">Import Quiz Data</button>
             <button class="btn btn-danger btn-small" onclick="resetProgress()">Reset All Progress</button>
-            <button class="btn btn-small" onclick="changeKeyword()" style="margin-top: 10px; opacity: 0.7;">Change Keyword</button>
         </div>
 
         <!-- Quiz Screen -->
@@ -1343,8 +1345,11 @@ question,answer,choice1,choice2,choice3,choice4,correct
             input.disabled = false;
         }
 
-        // Change to different keyword
+        // Sign out - change to different keyword
         function changeKeyword() {
+            // Clear saved keyword
+            localStorage.removeItem('quizmyself_keyword');
+
             currentKeyword = '';
             state.mastered = [];
             state.answerCounts = {};
@@ -1358,6 +1363,7 @@ question,answer,choice1,choice2,choice3,choice4,correct
             document.getElementById('keyword-screen').classList.remove('hidden');
             document.getElementById('stats-bar').style.display = 'none';
             document.getElementById('keyword-input').value = '';
+            document.getElementById('keyword-input').focus();
             updateStats();
             updateResumeExamButton(false);
         }


### PR DESCRIPTION
## Summary
- Add keyword bar at top with Sign Out button
- Clear localStorage on sign out
- Focus input after sign out

## Test plan
- [ ] Sign Out button visible in menu
- [ ] Clicking Sign Out returns to keyword screen
- [ ] Refreshing after sign out shows keyword prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)