### PR TITLE
Fix: Per-keyword Pro status and visible back button

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,10 +283,16 @@
             text-decoration: none;
             display: inline-block;
             margin-bottom: 20px;
+            padding: 8px 16px;
+            background: rgba(79, 195, 247, 0.1);
+            border: 1px solid #4fc3f7;
+            border-radius: 6px;
+            font-size: 14px;
         }
 
         .back-link:hover {
-            text-decoration: underline;
+            background: rgba(79, 195, 247, 0.2);
+            text-decoration: none;
         }
 
         .deploy-banner {
@@ -1335,6 +1341,9 @@ question,answer,choice1,choice2,choice3,choice4,correct
 
             // Load progress for this keyword
             await loadState();
+
+            // Check pro status for this keyword
+            await checkProStatus();
 
             // Show menu
             document.getElementById('keyword-screen').classList.add('hidden');
@@ -2703,7 +2712,10 @@ question,answer,choice1,choice2,choice3,choice4,correct
                     // License is valid - activate Pro
                     state.isPro = true;
                     state.licenseKey = licenseKey;
-                    localStorage.setItem('quizmyself_license', licenseKey);
+                    // Store license per-keyword
+                    if (currentKeyword) {
+                        localStorage.setItem(`quizmyself_license_${currentKeyword}`, licenseKey);
+                    }
                     updateProUI();
                     showUpgradeSuccess('License activated! Welcome to Pro!');
                     setTimeout(() => closeUpgradeModal(), 2000);
@@ -2752,8 +2764,18 @@ question,answer,choice1,choice2,choice3,choice4,correct
         }
 
         async function checkProStatus() {
-            // Check for stored license
-            const storedLicense = localStorage.getItem('quizmyself_license');
+            // Reset pro status
+            state.isPro = false;
+            state.licenseKey = null;
+
+            // Need keyword to check per-user license
+            if (!currentKeyword) {
+                updateProUI();
+                return;
+            }
+
+            // Check for stored license (per-keyword)
+            const storedLicense = localStorage.getItem(`quizmyself_license_${currentKeyword}`);
             if (storedLicense) {
                 try {
                     const response = await fetch(`${VANDROMEDA_API}/license/validate.php`, {
@@ -2772,7 +2794,7 @@ question,answer,choice1,choice2,choice3,choice4,correct
                         state.licenseKey = storedLicense;
                     } else {
                         // License expired or invalid - remove it
-                        localStorage.removeItem('quizmyself_license');
+                        localStorage.removeItem(`quizmyself_license_${currentKeyword}`);
                         state.isPro = false;
                         state.licenseKey = null;
                     }


### PR DESCRIPTION
## Summary
- Pro status is now per-keyword (different keywords can have different Pro status)
- Back button styled as a visible button instead of subtle link

## Test plan
- [ ] Sign in as keyword A, activate Pro
- [ ] Sign out, sign in as keyword B - should NOT be Pro
- [ ] Back button clearly visible in quiz/exam

🤖 Generated with [Claude Code](https://claude.com/claude-code)