### PR TITLE
Fix Pro license detection for Firebase users after login

### DIFF
--- a/index.html
+++ b/index.html
@@ -3686,7 +3686,15 @@ question,answer,choice1,choice2,choice3,choice4,correct
         }
 
         async function checkProStatus() {
-            // Reset pro status
+            // For Firebase users, license is tied to account (handled by checkProStatusForAccount)
+            // Don't override account-based pro status
+            if (currentUser) {
+                updateProUI();
+                updateHamburgerMenu();
+                return;
+            }
+
+            // Reset pro status for keyword-only users
             state.isPro = false;
             state.licenseKey = null;
             state.email = null;


### PR DESCRIPTION
The checkProStatus() function (for per-keyword license storage) was
resetting state.isPro to false even for Firebase users, overriding the
account-based license status set by checkProStatusForAccount().

Now checkProStatus() returns early for Firebase users since their license
is tied to their account, not per-keyword localStorage.