### PR TITLE
Fix question persistence and add compression

### DIFF
--- a/index.html
+++ b/index.html
@@ -2675,7 +2675,11 @@ question,answer,choice1,choice2,choice3,choice4,correct
                 <div class="keyword-item">
                     <div class="keyword-item-info">
                         <div class="keyword-item-name ${currentKeyword === kw.keyword ? 'active' : ''}">${kw.keyword}</div>
-                        <div class="keyword-item-date">Created: ${new Date(kw.created_at).toLocaleDateString()}${kw.is_migrated ? ' (Claimed)' : ''}</div>
+                        <div class="keyword-item-date">
+                            ${kw.question_count > 0 ? `<span style="color: #4fc3f7;">${kw.question_count} questions</span>` : '<span style="color: #666;">No questions</span>'}
+                            ${kw.source_count > 0 ? ` | <span style="color: #888;">${kw.source_count} source${kw.source_count > 1 ? 's' : ''}</span>` : ''}
+                            | ${new Date(kw.created_at).toLocaleDateString()}${kw.is_migrated ? ' (Claimed)' : ''}
+                        </div>
                     </div>
                     <div class="keyword-item-actions">
                         ${currentKeyword !== kw.keyword ?


### PR DESCRIPTION
## Summary
- Add gzip compression for source material storage (~70% size reduction)
- Fix question persistence - questions now saved/loaded per keyword
- Show question and source counts in keyword list modal

## Changes
1. **Compression**: Sources are gzip-compressed and base64-encoded before storage
2. **Question persistence**: `loadState()` loads customQuestions, `saveState()` saves them
3. **Keyword display**: Shows "42 questions | 2 sources" for each keyword

## Test plan
- [ ] Import a PDF or text file - verify questions are saved
- [ ] Refresh page - verify questions persist
- [ ] Switch keywords - verify each has its own questions
- [ ] Open "Manage Keywords" - verify counts display
- [ ] View imported sources - verify decompression works

🤖 Generated with [Claude Code](https://claude.com/claude-code)