### PR TITLE
Add debug logging for source linking issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -3573,6 +3573,9 @@ question,answer,choice1,choice2,choice3,choice4,correct
         function showCourseContent() {
             // Check if current keyword has a linked source - show that instead
             const keywordInfo = userKeywords.find(kw => kw.keyword === currentKeyword);
+            console.log('[DEBUG showCourseContent] currentKeyword:', currentKeyword);
+            console.log('[DEBUG showCourseContent] keywordInfo:', keywordInfo);
+            console.log('[DEBUG showCourseContent] source_id:', keywordInfo?.source_id, 'source_name:', keywordInfo?.source_name, 'content_type:', keywordInfo?.source_content_type);
             if (keywordInfo && keywordInfo.source_id) {
                 // Show the linked source in the format-aware viewer
                 openDataModal();
@@ -5227,8 +5230,10 @@ question,answer,choice1,choice2,choice3,choice4,correct
         }
 
         async function linkSourceToQuiz(sourceId, sourceName) {
+            console.log('[DEBUG linkSourceToQuiz] called with sourceId:', sourceId, 'sourceName:', sourceName);
             // Find quizzes without a linked source
             const unlinkedQuizzes = userKeywords.filter(kw => !kw.source_id);
+            console.log('[DEBUG linkSourceToQuiz] unlinkedQuizzes:', unlinkedQuizzes);
 
             if (unlinkedQuizzes.length === 0) {
                 alert('All your quizzes already have sources linked. Create a new quiz first.');
@@ -5257,19 +5262,22 @@ question,answer,choice1,choice2,choice3,choice4,correct
             }
 
             const selectedKeyword = unlinkedQuizzes[index].keyword;
+            console.log('[DEBUG linkSourceToQuiz] linking sourceId:', sourceId, 'to keyword:', selectedKeyword);
 
             try {
                 const token = await currentUser.getIdToken();
+                const requestBody = {
+                    sourceId: sourceId,
+                    keyword: selectedKeyword
+                };
+                console.log('[DEBUG linkSourceToQuiz] API request body:', requestBody);
                 const response = await fetch(`${VANDROMEDA_API}/quizmyself/link-source.php`, {
                     method: 'POST',
                     headers: {
                         'Authorization': `Bearer ${token}`,
                         'Content-Type': 'application/json'
                     },
-                    body: JSON.stringify({
-                        sourceId: sourceId,
-                        keyword: selectedKeyword
-                    })
+                    body: JSON.stringify(requestBody)
                 });
 
                 const data = await response.json();
@@ -5280,6 +5288,9 @@ question,answer,choice1,choice2,choice3,choice4,correct
 
                 alert(`Source linked to "${selectedKeyword}" successfully!`);
                 await loadUserKeywords(); // Refresh keywords to update source_id
+                console.log('[DEBUG linkSourceToQuiz] After loadUserKeywords, userKeywords:', userKeywords);
+                const linkedKw = userKeywords.find(kw => kw.keyword === selectedKeyword);
+                console.log('[DEBUG linkSourceToQuiz] Linked keyword info:', linkedKw);
                 loadSources(); // Refresh the sources list
 
             } catch (err) {


### PR DESCRIPTION
## Summary
- Adds console.log statements to track source IDs and keywords during link operation
- Helps identify why linking to PDF shows HTML content instead

## To test
1. Open browser console (F12 > Console)
2. Go to Quiz Data modal
3. Click Link on PDF source
4. Select somemath quiz
5. Click View Study Material
6. Check console for DEBUG messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)