### PR TITLE
fix: clear quiz UI on logout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2560,6 +2560,7 @@
             authToken = null;
             userKeywords = [];
             currentKeyword = '';
+            questions = [];
             state.isPro = false;
             state.licenseKey = null;
             state.email = null;
@@ -2568,6 +2569,7 @@
             localStorage.removeItem('quizmyself_active_keyword');
             document.getElementById('stats-bar').style.display = 'none';
             document.getElementById('hamburger-dropdown').classList.remove('show');
+            updateKeywordDropdown();
             updateHamburgerMenu();
             updateProUI();
             showScreen('menu-screen');


### PR DESCRIPTION
## Summary
- Added `updateKeywordDropdown()` call to hide quiz selector on logout
- Clear `questions` array to remove quiz content from memory

## Why
Quizzes were still visible on screen after logging out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)