### PR TITLE
fix: disable deployment status check (GitHub API rate limits)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6782,37 +6782,14 @@
             updateHamburgerMenu();
             updateStats();
         })();
-        checkDeploymentStatus();
+        // Deployment status check disabled - GitHub API rate limits cause 403 errors
+        // TODO: Re-enable with GitHub token or alternative approach (issue #112)
+        // checkDeploymentStatus();
 
-        // Check if there's a newer version being deployed
         async function checkDeploymentStatus() {
-            const REPO = 'FullStackKevinVanDriel/QuizMyself';
-            const deployedSha = document.querySelector('meta[name="deployed-sha"]')?.content;
-
-            try {
-                // Get latest commit SHA
-                const commitRes = await fetch(`https://api.github.com/repos/${REPO}/commits/main`);
-                if (!commitRes.ok) return;
-                const commitData = await commitRes.json();
-                const latestSha = commitData.sha;
-
-                // If deployed SHA doesn't match latest, check build status
-                if (deployedSha && deployedSha !== '__COMMIT_SHA__' && deployedSha !== latestSha) {
-                    showDeployBanner('New version merged, deploying...');
-                    return;
-                }
-
-                // Also check if Pages is currently building
-                const pagesRes = await fetch(`https://api.github.com/repos/${REPO}/pages/builds`);
-                if (!pagesRes.ok) return;
-                const builds = await pagesRes.json();
-
-                if (builds[0]?.status === 'building' || builds[0]?.status === 'queued') {
-                    showDeployBanner('Deploying update...');
-                }
-            } catch (e) {
-                // Silently fail - don't disrupt the quiz
-            }
+            // Disabled due to GitHub API rate limits (60 req/hr unauthenticated)
+            // To re-enable, add a GitHub token or use a different approach
+            return;
         }
 
         function showDeployBanner(message) {


### PR DESCRIPTION
Disables the deployment status banner feature to stop GitHub API 403 errors in console.