### PR TITLE
fix: use correct API variable in URL scraper

### DIFF
--- a/index.html
+++ b/index.html
@@ -6110,7 +6110,7 @@
 
             try {
                 const token = await currentUser.getIdToken();
-                const response = await fetch(`${API_BASE}/quizmyself/scrape-url.php`, {
+                const response = await fetch(`${VANDROMEDA_API}/quizmyself/scrape-url.php`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',


### PR DESCRIPTION
Fix API_BASE → VANDROMEDA_API to resolve 'API_BASE is not defined' error when importing URLs.