### PR TITLE
feat: show feedback IDs in roadmap and after submission

### DIFF
--- a/.github/workflows/update-roadmap.yml
+++ b/.github/workflows/update-roadmap.yml
@@ -196,16 +196,29 @@ jobs:
               // -------------------------------------------------------------------
               // Format issues for output
               // -------------------------------------------------------------------
-              const formatIssue = (issue) => ({
-                number: issue.number,
-                title: issue.title,
-                state: issue.state,
-                labels: issue.labels.map(l => typeof l === 'string' ? l : l.name),
-                createdAt: issue.created_at,
-                updatedAt: issue.updated_at,
-                milestone: issue.milestone ? issue.milestone.title : null,
-                url: issue.html_url
-              });
+              const formatIssue = (issue) => {
+                // Extract feedback_id from issue body if present
+                // Format: <!-- feedback_id: 123 -->
+                let feedbackId = null;
+                if (issue.body) {
+                  const match = issue.body.match(/<!--\s*feedback_id:\s*(\d+)\s*-->/);
+                  if (match) {
+                    feedbackId = parseInt(match[1], 10);
+                  }
+                }
+
+                return {
+                  number: issue.number,
+                  title: issue.title,
+                  state: issue.state,
+                  labels: issue.labels.map(l => typeof l === 'string' ? l : l.name),
+                  createdAt: issue.created_at,
+                  updatedAt: issue.updated_at,
+                  milestone: issue.milestone ? issue.milestone.title : null,
+                  url: issue.html_url,
+                  feedback_id: feedbackId
+                };
+              };
 
               const formattedIssues = allFilteredIssues
                 .map(formatIssue)
@@ -215,11 +228,20 @@ jobs:
               // Get recently completed issues (last 30 days)
               // -------------------------------------------------------------------
               const recentlyCompleted = filteredClosedIssues
-                .map(issue => ({
-                  number: issue.number,
-                  title: issue.title,
-                  closedAt: issue.closed_at
-                }))
+                .map(issue => {
+                  let feedbackId = null;
+                  if (issue.body) {
+                    const match = issue.body.match(/<!--\s*feedback_id:\s*(\d+)\s*-->/);
+                    if (match) feedbackId = parseInt(match[1], 10);
+                  }
+                  return {
+                    number: issue.number,
+                    title: issue.title,
+                    closedAt: issue.closed_at,
+                    url: issue.html_url,
+                    feedback_id: feedbackId
+                  };
+                })
                 .sort((a, b) => new Date(b.closedAt) - new Date(a.closedAt))
                 .slice(0, 10); // Limit to 10 most recently completed
 

--- a/index.html
+++ b/index.html
@@ -1573,6 +1573,21 @@
             flex: 1;
         }
 
+        .roadmap-item-refs {
+            color: #888;
+            font-size: 0.85rem;
+            font-weight: normal;
+            margin-right: 8px;
+        }
+
+        .roadmap-item-refs a {
+            text-decoration: none;
+        }
+
+        .roadmap-item-refs a:hover {
+            text-decoration: underline;
+        }
+
         .roadmap-item-meta {
             color: #666;
             font-size: 0.8rem;
@@ -4438,10 +4453,23 @@
 
             const timeAgo = issue.created_at ? formatRelativeTime(issue.created_at) : '';
 
+            // Build reference numbers (feedback ID and/or GitHub issue)
+            let refHtml = '';
+            if (issue.feedback_id || issue.number) {
+                const refs = [];
+                if (issue.feedback_id) refs.push(`#${issue.feedback_id}`);
+                if (issue.number && issue.url) {
+                    refs.push(`<a href="${escapeAttr(issue.url)}" target="_blank" rel="noopener" style="color: #4fc3f7;">GH-${issue.number}</a>`);
+                } else if (issue.number) {
+                    refs.push(`GH-${issue.number}`);
+                }
+                refHtml = `<span class="roadmap-item-refs">${refs.join(' | ')}</span>`;
+            }
+
             return `
                 <div class="roadmap-item">
                     <div class="roadmap-item-header">
-                        <div class="roadmap-item-title">${escapeHtml(issue.title)}</div>
+                        <div class="roadmap-item-title">${refHtml}${escapeHtml(issue.title)}</div>
                         <div class="roadmap-item-meta">${timeAgo}</div>
                     </div>
                     ${labelsHtml}
@@ -4491,7 +4519,10 @@
                     statusEl.style.display = 'block';
                     statusEl.style.background = 'rgba(79,195,247,0.1)';
                     statusEl.style.color = '#4fc3f7';
-                    statusEl.textContent = 'Thank you for your feedback! We will review it soon.';
+                    const feedbackId = result.feedback_id || result.id;
+                    statusEl.textContent = feedbackId
+                        ? `Thank you! Your feedback #${feedbackId} has been submitted.`
+                        : 'Thank you for your feedback! We will review it soon.';
                     submitBtn.textContent = 'Sent!';
                     // Close modal after delay
                     setTimeout(() => {

--- a/vandromeda-api/.env.example
+++ b/vandromeda-api/.env.example
@@ -1,0 +1,27 @@
+# Vandromeda Feedback API Environment Configuration
+# Copy this file to .env and fill in your values
+# chmod 600 .env to restrict permissions
+
+# ===================
+# Database Configuration
+# ===================
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=vandromeda
+DB_USER=your_database_user
+DB_PASS=your_database_password
+
+# ===================
+# Mail Configuration
+# ===================
+# Used by feedback-notify.php for sending emails
+
+# SMTP Settings (optional - falls back to PHP mail())
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_smtp_username
+SMTP_PASS=your_smtp_password
+
+# From Address
+MAIL_FROM=noreply@vandromeda.com
+MAIL_FROM_NAME=Vandromeda Feedback

--- a/vandromeda-api/README.md
+++ b/vandromeda-api/README.md
@@ -1,0 +1,441 @@
+# Vandromeda Feedback API
+
+PHP API endpoints for the feedback integration system. These files handle feedback management, GitHub issue linking, and user notifications for QuizMyself and other Vandromeda products.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `feedback.php` | Main API endpoint for CRUD operations on feedback |
+| `feedback-notify.php` | Sends email notifications to feedback submitters |
+| `generate-token.php` | CLI script to generate API authentication tokens |
+| `.env.example` | Example environment configuration |
+
+## Deployment
+
+### 1. Upload Files
+
+Upload all PHP files to your Vandromeda server's web-accessible directory:
+
+```bash
+scp *.php user@vandromeda.com:/var/www/api/feedback/
+```
+
+### 2. Create Environment Configuration
+
+Copy the example environment file and configure it:
+
+```bash
+cp .env.example .env
+chmod 600 .env  # Restrict permissions
+```
+
+Edit `.env` with your database and mail settings.
+
+### 3. Database Setup
+
+Run the following SQL to create the required tables:
+
+```sql
+-- Feedback storage table
+CREATE TABLE feedback (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    product VARCHAR(50) NOT NULL,
+    type VARCHAR(20) NOT NULL,
+    message TEXT NOT NULL,
+    email VARCHAR(255),
+    user_agent TEXT,
+    url VARCHAR(500),
+    context JSON,
+    status VARCHAR(20) DEFAULT 'pending',
+    github_issue INT,
+    github_issue_url VARCHAR(500),
+    processed_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_product (product),
+    INDEX idx_status (status),
+    INDEX idx_created (created_at),
+    INDEX idx_processed (processed_at)
+);
+
+-- API tokens table
+CREATE TABLE api_tokens (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    token VARCHAR(64) UNIQUE NOT NULL,
+    name VARCHAR(100),
+    permissions JSON,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    expires_at DATETIME,
+    INDEX idx_token (token),
+    INDEX idx_expires (expires_at)
+);
+
+-- Optional: Notification log table (auto-created by feedback-notify.php)
+CREATE TABLE IF NOT EXISTS feedback_notifications (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    feedback_id INT NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    sent_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    success BOOLEAN DEFAULT TRUE,
+    error_message TEXT,
+    INDEX idx_feedback_id (feedback_id)
+);
+```
+
+### 4. Generate API Token
+
+Generate a token for authenticating API requests:
+
+```bash
+php generate-token.php --name="GitHub Actions CI" --permissions="feedback:read,feedback:write"
+```
+
+Save the generated token securely - it won't be shown again.
+
+## Environment Variables
+
+Create a `.env` file in the same directory as the PHP files:
+
+```env
+# Database Configuration
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=vandromeda
+DB_USER=your_username
+DB_PASS=your_password
+
+# Mail Configuration (optional - for notifications)
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_smtp_user
+SMTP_PASS=your_smtp_password
+MAIL_FROM=noreply@vandromeda.com
+MAIL_FROM_NAME=Vandromeda Feedback
+```
+
+## API Reference
+
+### Authentication
+
+All endpoints require Bearer token authentication:
+
+```
+Authorization: Bearer your_api_token_here
+```
+
+### Permissions
+
+| Permission | Description |
+|------------|-------------|
+| `feedback:read` | Read feedback entries |
+| `feedback:write` | Create/update feedback entries |
+| `feedback:notify` | Send notification emails |
+| `*` | All permissions |
+
+---
+
+## Endpoints
+
+### GET /feedback.php
+
+Retrieve feedback entries.
+
+**Query Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `product` | string | Filter by product (e.g., "quizmyself") |
+| `unprocessed` | boolean | Set to "true" to get only unprocessed feedback |
+| `status` | string | Filter by status (pending, processing, resolved, etc.) |
+| `limit` | int | Max entries to return (default: 100, max: 500) |
+| `offset` | int | Pagination offset (default: 0) |
+
+**Example:**
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.vandromeda.com/feedback.php?product=quizmyself&unprocessed=true"
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": 123,
+      "product": "quizmyself",
+      "type": "bug",
+      "message": "Login button not working",
+      "email": "user@example.com",
+      "user_agent": "Mozilla/5.0...",
+      "url": "https://quizmyself.com/login",
+      "context": {"browser": "Chrome", "os": "Windows"},
+      "status": "pending",
+      "github_issue": null,
+      "github_issue_url": null,
+      "processed_at": null,
+      "created_at": "2025-01-15 10:30:00"
+    }
+  ],
+  "pagination": {
+    "total": 42,
+    "limit": 100,
+    "offset": 0,
+    "has_more": false
+  }
+}
+```
+
+---
+
+### POST /feedback.php
+
+Mark feedback as processed and link to GitHub issue.
+
+**Request Body:**
+
+```json
+{
+  "action": "mark_processed",
+  "feedback_id": 123,
+  "github_issue": 456,
+  "github_issue_url": "https://github.com/org/repo/issues/456"
+}
+```
+
+**Example:**
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"mark_processed","feedback_id":123,"github_issue":456,"github_issue_url":"https://github.com/org/repo/issues/456"}' \
+  "https://api.vandromeda.com/feedback.php"
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "message": "Feedback marked as processed",
+  "data": {
+    "id": 123,
+    "status": "processing",
+    "github_issue": 456,
+    "github_issue_url": "https://github.com/org/repo/issues/456",
+    "processed_at": "2025-01-15 11:00:00"
+  }
+}
+```
+
+---
+
+### PATCH /feedback.php
+
+Update feedback status.
+
+**Request Body:**
+
+```json
+{
+  "feedback_id": 123,
+  "status": "resolved",
+  "github_issue_url": "https://github.com/org/repo/issues/456"
+}
+```
+
+**Valid Status Values:**
+- `pending` - Not yet reviewed
+- `processing` - Being worked on
+- `resolved` - Fixed/addressed
+- `wontfix` - Won't be fixed
+- `duplicate` - Duplicate of another issue
+- `invalid` - Not a valid issue
+
+**Example:**
+
+```bash
+curl -X PATCH \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"feedback_id":123,"status":"resolved"}' \
+  "https://api.vandromeda.com/feedback.php"
+```
+
+---
+
+### POST /feedback-notify.php
+
+Send email notification to feedback submitter.
+
+**Request Body:**
+
+```json
+{
+  "feedback_id": 123,
+  "message": "Thank you for your feedback! We've fixed the login issue in our latest update.",
+  "subject": "Your feedback has been addressed"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `feedback_id` | Yes | ID of the feedback entry |
+| `message` | Yes | Message to send to the user (max 5000 chars) |
+| `subject` | No | Custom email subject (auto-generated if omitted) |
+
+**Example:**
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"feedback_id":123,"message":"We have fixed this issue. Thank you!"}' \
+  "https://api.vandromeda.com/feedback-notify.php"
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "message": "Notification email sent successfully",
+  "data": {
+    "feedback_id": 123,
+    "email": "user@example.com",
+    "subject": "Update on your Bug Report - QuizMyself"
+  }
+}
+```
+
+---
+
+## Error Responses
+
+All endpoints return errors in this format:
+
+```json
+{
+  "error": true,
+  "message": "Description of the error"
+}
+```
+
+**HTTP Status Codes:**
+
+| Code | Meaning |
+|------|---------|
+| 400 | Bad Request - Invalid parameters |
+| 401 | Unauthorized - Missing or invalid token |
+| 403 | Forbidden - Token lacks required permission |
+| 404 | Not Found - Feedback entry not found |
+| 405 | Method Not Allowed |
+| 500 | Internal Server Error |
+
+---
+
+## Token Management
+
+### Generate a New Token
+
+```bash
+# Default token with all feedback permissions
+php generate-token.php
+
+# Named token with specific permissions
+php generate-token.php --name="CI/CD Pipeline" --permissions="feedback:read,feedback:write"
+
+# Token with expiration
+php generate-token.php --name="Temp Access" --permissions="feedback:read" --expires=30
+
+# Admin token with all permissions
+php generate-token.php --name="Admin" --permissions="*"
+```
+
+### Token Options
+
+| Option | Description |
+|--------|-------------|
+| `--name=NAME` | Descriptive name for the token |
+| `--permissions=PERMS` | Comma-separated list of permissions |
+| `--expires=DAYS` | Token expiration in days |
+| `--help` | Show help message |
+
+---
+
+## Integration Example
+
+Here's how the feedback system integrates with a GitHub Actions workflow:
+
+```yaml
+name: Process Feedback
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # Every 6 hours
+  workflow_dispatch:
+
+jobs:
+  process-feedback:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch unprocessed feedback
+        id: fetch
+        run: |
+          response=$(curl -s -H "Authorization: Bearer ${{ secrets.VANDROMEDA_TOKEN }}" \
+            "https://api.vandromeda.com/feedback.php?product=quizmyself&unprocessed=true")
+          echo "feedback=$response" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub issues
+        run: |
+          # Process feedback and create issues...
+          # Then mark as processed via POST to feedback.php
+```
+
+---
+
+## Security Considerations
+
+1. **Token Storage**: Never commit tokens to version control. Use environment variables or secrets management.
+
+2. **File Permissions**: Restrict `.env` file permissions:
+   ```bash
+   chmod 600 .env
+   ```
+
+3. **HTTPS**: Always use HTTPS in production to protect token transmission.
+
+4. **Token Rotation**: Periodically rotate API tokens, especially after team member departures.
+
+5. **Minimal Permissions**: Grant tokens only the permissions they need.
+
+---
+
+## Troubleshooting
+
+### Database Connection Failed
+
+- Verify `.env` file exists and has correct credentials
+- Check MySQL is running: `systemctl status mysql`
+- Verify database and user exist
+
+### Token Authentication Fails
+
+- Ensure token hasn't expired
+- Check Authorization header format: `Bearer <token>`
+- Verify token exists in database: `SELECT * FROM api_tokens WHERE token='...'`
+
+### Email Not Sending
+
+- Check mail server configuration
+- Verify `mail()` function is enabled in PHP
+- Check server mail logs: `/var/log/mail.log`
+- Consider using a dedicated SMTP service
+
+### Permission Denied
+
+- Verify token has required permission in database
+- Check permissions JSON format: `["feedback:read", "feedback:write"]`

--- a/vandromeda-api/feedback-notify.php
+++ b/vandromeda-api/feedback-notify.php
@@ -1,0 +1,389 @@
+<?php
+/**
+ * Feedback Notification Endpoint
+ *
+ * Sends email notifications to feedback submitters when their feedback
+ * has been addressed or requires follow-up.
+ *
+ * POST - Send email notification to feedback submitter
+ * Body: { "feedback_id": 123, "message": "Your feedback has been addressed!" }
+ */
+
+declare(strict_types=1);
+
+// CORS headers
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+header('Content-Type: application/json; charset=utf-8');
+
+// Handle preflight requests
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+// Only allow POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => true, 'message' => 'Method not allowed']);
+    exit;
+}
+
+// Load environment variables from .env file if it exists
+function loadEnv(string $path): void {
+    if (!file_exists($path)) {
+        return;
+    }
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        if (strpos(trim($line), '#') === 0) {
+            continue;
+        }
+        if (strpos($line, '=') !== false) {
+            list($name, $value) = explode('=', $line, 2);
+            $name = trim($name);
+            $value = trim($value, " \t\n\r\0\x0B\"'");
+            if (!getenv($name)) {
+                putenv("$name=$value");
+                $_ENV[$name] = $value;
+            }
+        }
+    }
+}
+
+loadEnv(__DIR__ . '/.env');
+
+/**
+ * Send a JSON response and exit
+ */
+function jsonResponse(array $data, int $statusCode = 200): void {
+    http_response_code($statusCode);
+    echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+/**
+ * Send an error response and exit
+ */
+function errorResponse(string $message, int $statusCode = 400): void {
+    jsonResponse(['error' => true, 'message' => $message], $statusCode);
+}
+
+/**
+ * Get database connection
+ */
+function getDbConnection(): PDO {
+    $host = getenv('DB_HOST') ?: 'localhost';
+    $port = getenv('DB_PORT') ?: '3306';
+    $dbname = getenv('DB_NAME') ?: 'vandromeda';
+    $username = getenv('DB_USER') ?: 'root';
+    $password = getenv('DB_PASS') ?: '';
+
+    try {
+        $dsn = "mysql:host=$host;port=$port;dbname=$dbname;charset=utf8mb4";
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES => false,
+        ];
+        return new PDO($dsn, $username, $password, $options);
+    } catch (PDOException $e) {
+        error_log("Database connection failed: " . $e->getMessage());
+        errorResponse('Database connection failed', 500);
+    }
+}
+
+/**
+ * Authenticate the request using Bearer token
+ */
+function authenticate(PDO $db): array {
+    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+
+    if (empty($authHeader)) {
+        errorResponse('Authorization header required', 401);
+    }
+
+    if (!preg_match('/^Bearer\s+(.+)$/i', $authHeader, $matches)) {
+        errorResponse('Invalid authorization format. Use: Bearer <token>', 401);
+    }
+
+    $token = $matches[1];
+
+    $stmt = $db->prepare("
+        SELECT id, name, permissions, expires_at
+        FROM api_tokens
+        WHERE token = ?
+        AND (expires_at IS NULL OR expires_at > NOW())
+    ");
+    $stmt->execute([$token]);
+    $tokenData = $stmt->fetch();
+
+    if (!$tokenData) {
+        errorResponse('Invalid or expired token', 401);
+    }
+
+    $permissions = json_decode($tokenData['permissions'] ?? '[]', true) ?: [];
+
+    return [
+        'id' => $tokenData['id'],
+        'name' => $tokenData['name'],
+        'permissions' => $permissions,
+    ];
+}
+
+/**
+ * Check if token has required permission
+ */
+function hasPermission(array $tokenData, string $permission): bool {
+    $permissions = $tokenData['permissions'];
+    return in_array('*', $permissions) || in_array($permission, $permissions);
+}
+
+/**
+ * Send email using PHP mail() or SMTP
+ */
+function sendEmail(string $to, string $subject, string $htmlBody, string $textBody): bool {
+    $smtpHost = getenv('SMTP_HOST');
+    $smtpPort = getenv('SMTP_PORT') ?: 587;
+    $smtpUser = getenv('SMTP_USER');
+    $smtpPass = getenv('SMTP_PASS');
+    $fromEmail = getenv('MAIL_FROM') ?: 'noreply@vandromeda.com';
+    $fromName = getenv('MAIL_FROM_NAME') ?: 'Vandromeda Feedback';
+
+    // If SMTP is configured, try to use it via PHPMailer or similar
+    // For now, we'll use the native mail() function with proper headers
+    // In production, you might want to integrate PHPMailer or similar
+
+    $boundary = md5(uniqid((string)time()));
+
+    $headers = [
+        'MIME-Version: 1.0',
+        "From: $fromName <$fromEmail>",
+        'Reply-To: ' . $fromEmail,
+        'X-Mailer: PHP/' . phpversion(),
+        "Content-Type: multipart/alternative; boundary=\"$boundary\"",
+    ];
+
+    $body = "--$boundary\r\n";
+    $body .= "Content-Type: text/plain; charset=UTF-8\r\n";
+    $body .= "Content-Transfer-Encoding: 8bit\r\n\r\n";
+    $body .= $textBody . "\r\n\r\n";
+    $body .= "--$boundary\r\n";
+    $body .= "Content-Type: text/html; charset=UTF-8\r\n";
+    $body .= "Content-Transfer-Encoding: 8bit\r\n\r\n";
+    $body .= $htmlBody . "\r\n\r\n";
+    $body .= "--$boundary--";
+
+    // Try mail() function
+    $result = @mail($to, $subject, $body, implode("\r\n", $headers));
+
+    if (!$result) {
+        error_log("Failed to send email to: $to");
+    }
+
+    return $result;
+}
+
+/**
+ * Build email content from template
+ */
+function buildEmailContent(array $feedback, string $message, string $productName): array {
+    $feedbackType = ucfirst($feedback['type'] ?? 'feedback');
+    $feedbackId = $feedback['id'];
+    $status = ucfirst($feedback['status'] ?? 'unknown');
+
+    $textBody = <<<TEXT
+Hello,
+
+Thank you for submitting your $feedbackType for $productName.
+
+$message
+
+---
+Feedback Reference: #$feedbackId
+Status: $status
+
+If you have any questions, please don't hesitate to reach out.
+
+Best regards,
+The $productName Team
+TEXT;
+
+    $htmlBody = <<<HTML
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: #4f46e5; color: white; padding: 20px; border-radius: 8px 8px 0 0; }
+        .content { background: #f9fafb; padding: 20px; border: 1px solid #e5e7eb; }
+        .footer { background: #f3f4f6; padding: 15px; border-radius: 0 0 8px 8px; font-size: 12px; color: #6b7280; border: 1px solid #e5e7eb; border-top: none; }
+        .message { background: white; padding: 15px; border-radius: 6px; border-left: 4px solid #4f46e5; margin: 15px 0; }
+        .meta { font-size: 13px; color: #6b7280; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h2 style="margin: 0;">$productName Feedback Update</h2>
+        </div>
+        <div class="content">
+            <p>Hello,</p>
+            <p>Thank you for submitting your <strong>$feedbackType</strong> for $productName.</p>
+
+            <div class="message">
+                <p style="margin: 0;">$message</p>
+            </div>
+
+            <div class="meta">
+                <p><strong>Feedback Reference:</strong> #$feedbackId<br>
+                <strong>Status:</strong> $status</p>
+            </div>
+
+            <p>If you have any questions, please don't hesitate to reach out.</p>
+
+            <p>Best regards,<br>The $productName Team</p>
+        </div>
+        <div class="footer">
+            <p style="margin: 0;">This email was sent regarding your feedback submission. Please do not reply to this email.</p>
+        </div>
+    </div>
+</body>
+</html>
+HTML;
+
+    return [
+        'text' => $textBody,
+        'html' => $htmlBody,
+    ];
+}
+
+/**
+ * Log notification to database (optional - creates table if needed)
+ */
+function logNotification(PDO $db, int $feedbackId, string $email, bool $success, ?string $error = null): void {
+    try {
+        // Check if notifications table exists, create if not
+        $db->exec("
+            CREATE TABLE IF NOT EXISTS feedback_notifications (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                feedback_id INT NOT NULL,
+                email VARCHAR(255) NOT NULL,
+                sent_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                success BOOLEAN DEFAULT TRUE,
+                error_message TEXT,
+                INDEX idx_feedback_id (feedback_id)
+            )
+        ");
+
+        $stmt = $db->prepare("
+            INSERT INTO feedback_notifications (feedback_id, email, success, error_message)
+            VALUES (?, ?, ?, ?)
+        ");
+        $stmt->execute([$feedbackId, $email, $success ? 1 : 0, $error]);
+    } catch (PDOException $e) {
+        // Log but don't fail if notification logging fails
+        error_log("Failed to log notification: " . $e->getMessage());
+    }
+}
+
+// Main execution
+try {
+    $db = getDbConnection();
+    $tokenData = authenticate($db);
+
+    if (!hasPermission($tokenData, 'feedback:notify')) {
+        errorResponse('Permission denied: feedback:notify required', 403);
+    }
+
+    // Parse request body
+    $input = json_decode(file_get_contents('php://input'), true);
+
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        errorResponse('Invalid JSON in request body');
+    }
+
+    // Validate required fields
+    $feedbackId = (int)($input['feedback_id'] ?? 0);
+    $message = trim($input['message'] ?? '');
+
+    if ($feedbackId <= 0) {
+        errorResponse('feedback_id is required and must be a positive integer');
+    }
+
+    if (empty($message)) {
+        errorResponse('message is required and cannot be empty');
+    }
+
+    if (strlen($message) > 5000) {
+        errorResponse('message must be 5000 characters or less');
+    }
+
+    // Optional subject override
+    $subject = trim($input['subject'] ?? '');
+
+    // Fetch feedback record
+    $stmt = $db->prepare("SELECT * FROM feedback WHERE id = ?");
+    $stmt->execute([$feedbackId]);
+    $feedback = $stmt->fetch();
+
+    if (!$feedback) {
+        errorResponse('Feedback not found', 404);
+    }
+
+    $email = $feedback['email'] ?? '';
+
+    if (empty($email)) {
+        errorResponse('Feedback has no email address associated', 400);
+    }
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        errorResponse('Invalid email address in feedback record', 400);
+    }
+
+    // Determine product name for email
+    $productNames = [
+        'quizmyself' => 'QuizMyself',
+        // Add more product mappings as needed
+    ];
+    $productName = $productNames[$feedback['product'] ?? ''] ?? ucfirst($feedback['product'] ?? 'Our Product');
+
+    // Build email subject
+    if (empty($subject)) {
+        $feedbackType = ucfirst($feedback['type'] ?? 'Feedback');
+        $subject = "Update on your $feedbackType - $productName";
+    }
+
+    // Build email content
+    $emailContent = buildEmailContent($feedback, $message, $productName);
+
+    // Send the email
+    $sent = sendEmail($email, $subject, $emailContent['html'], $emailContent['text']);
+
+    // Log the notification attempt
+    logNotification($db, $feedbackId, $email, $sent, $sent ? null : 'mail() function returned false');
+
+    if ($sent) {
+        jsonResponse([
+            'success' => true,
+            'message' => 'Notification email sent successfully',
+            'data' => [
+                'feedback_id' => $feedbackId,
+                'email' => $email,
+                'subject' => $subject,
+            ],
+        ]);
+    } else {
+        errorResponse('Failed to send notification email. Please check server mail configuration.', 500);
+    }
+
+} catch (PDOException $e) {
+    error_log("Database error: " . $e->getMessage());
+    errorResponse('Database error occurred', 500);
+} catch (Exception $e) {
+    error_log("Unexpected error: " . $e->getMessage());
+    errorResponse('An unexpected error occurred', 500);
+}

--- a/vandromeda-api/feedback.php
+++ b/vandromeda-api/feedback.php
@@ -1,0 +1,369 @@
+<?php
+/**
+ * Feedback API Endpoint
+ *
+ * Handles feedback operations for the QuizMyself product integration.
+ *
+ * GET  ?product=quizmyself&unprocessed=true - Returns unprocessed feedback
+ * POST action=mark_processed               - Marks feedback as processed with GitHub issue link
+ * PATCH                                     - Updates feedback status
+ */
+
+declare(strict_types=1);
+
+// CORS headers
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, PATCH, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+header('Content-Type: application/json; charset=utf-8');
+
+// Handle preflight requests
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+// Load environment variables from .env file if it exists
+function loadEnv(string $path): void {
+    if (!file_exists($path)) {
+        return;
+    }
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        if (strpos(trim($line), '#') === 0) {
+            continue;
+        }
+        if (strpos($line, '=') !== false) {
+            list($name, $value) = explode('=', $line, 2);
+            $name = trim($name);
+            $value = trim($value, " \t\n\r\0\x0B\"'");
+            if (!getenv($name)) {
+                putenv("$name=$value");
+                $_ENV[$name] = $value;
+            }
+        }
+    }
+}
+
+loadEnv(__DIR__ . '/.env');
+
+/**
+ * Send a JSON response and exit
+ */
+function jsonResponse(array $data, int $statusCode = 200): void {
+    http_response_code($statusCode);
+    echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+/**
+ * Send an error response and exit
+ */
+function errorResponse(string $message, int $statusCode = 400): void {
+    jsonResponse(['error' => true, 'message' => $message], $statusCode);
+}
+
+/**
+ * Get database connection
+ */
+function getDbConnection(): PDO {
+    $host = getenv('DB_HOST') ?: 'localhost';
+    $port = getenv('DB_PORT') ?: '3306';
+    $dbname = getenv('DB_NAME') ?: 'vandromeda';
+    $username = getenv('DB_USER') ?: 'root';
+    $password = getenv('DB_PASS') ?: '';
+
+    try {
+        $dsn = "mysql:host=$host;port=$port;dbname=$dbname;charset=utf8mb4";
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES => false,
+        ];
+        return new PDO($dsn, $username, $password, $options);
+    } catch (PDOException $e) {
+        error_log("Database connection failed: " . $e->getMessage());
+        errorResponse('Database connection failed', 500);
+    }
+}
+
+/**
+ * Authenticate the request using Bearer token
+ */
+function authenticate(PDO $db): array {
+    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+
+    if (empty($authHeader)) {
+        errorResponse('Authorization header required', 401);
+    }
+
+    if (!preg_match('/^Bearer\s+(.+)$/i', $authHeader, $matches)) {
+        errorResponse('Invalid authorization format. Use: Bearer <token>', 401);
+    }
+
+    $token = $matches[1];
+
+    $stmt = $db->prepare("
+        SELECT id, name, permissions, expires_at
+        FROM api_tokens
+        WHERE token = ?
+        AND (expires_at IS NULL OR expires_at > NOW())
+    ");
+    $stmt->execute([$token]);
+    $tokenData = $stmt->fetch();
+
+    if (!$tokenData) {
+        errorResponse('Invalid or expired token', 401);
+    }
+
+    $permissions = json_decode($tokenData['permissions'] ?? '[]', true) ?: [];
+
+    return [
+        'id' => $tokenData['id'],
+        'name' => $tokenData['name'],
+        'permissions' => $permissions,
+    ];
+}
+
+/**
+ * Check if token has required permission
+ */
+function hasPermission(array $tokenData, string $permission): bool {
+    $permissions = $tokenData['permissions'];
+    return in_array('*', $permissions) || in_array($permission, $permissions);
+}
+
+/**
+ * Handle GET requests - retrieve feedback
+ */
+function handleGet(PDO $db, array $tokenData): void {
+    if (!hasPermission($tokenData, 'feedback:read')) {
+        errorResponse('Permission denied: feedback:read required', 403);
+    }
+
+    $product = $_GET['product'] ?? null;
+    $unprocessed = isset($_GET['unprocessed']) && $_GET['unprocessed'] === 'true';
+    $status = $_GET['status'] ?? null;
+    $limit = min((int)($_GET['limit'] ?? 100), 500);
+    $offset = max((int)($_GET['offset'] ?? 0), 0);
+
+    $conditions = [];
+    $params = [];
+
+    if ($product) {
+        $conditions[] = 'product = ?';
+        $params[] = $product;
+    }
+
+    if ($unprocessed) {
+        $conditions[] = 'processed_at IS NULL';
+    }
+
+    if ($status) {
+        $conditions[] = 'status = ?';
+        $params[] = $status;
+    }
+
+    $whereClause = '';
+    if (!empty($conditions)) {
+        $whereClause = 'WHERE ' . implode(' AND ', $conditions);
+    }
+
+    // Get total count
+    $countStmt = $db->prepare("SELECT COUNT(*) as total FROM feedback $whereClause");
+    $countStmt->execute($params);
+    $total = (int)$countStmt->fetch()['total'];
+
+    // Get feedback items
+    $sql = "
+        SELECT id, product, type, message, email, user_agent, url, context,
+               status, github_issue, github_issue_url, processed_at, created_at
+        FROM feedback
+        $whereClause
+        ORDER BY created_at DESC
+        LIMIT ? OFFSET ?
+    ";
+
+    $stmt = $db->prepare($sql);
+    $params[] = $limit;
+    $params[] = $offset;
+    $stmt->execute($params);
+    $feedback = $stmt->fetchAll();
+
+    // Parse JSON context field
+    foreach ($feedback as &$item) {
+        $item['context'] = json_decode($item['context'] ?? '{}', true);
+    }
+
+    jsonResponse([
+        'success' => true,
+        'data' => $feedback,
+        'pagination' => [
+            'total' => $total,
+            'limit' => $limit,
+            'offset' => $offset,
+            'has_more' => ($offset + $limit) < $total,
+        ],
+    ]);
+}
+
+/**
+ * Handle POST requests - mark feedback as processed
+ */
+function handlePost(PDO $db, array $tokenData): void {
+    if (!hasPermission($tokenData, 'feedback:write')) {
+        errorResponse('Permission denied: feedback:write required', 403);
+    }
+
+    $input = json_decode(file_get_contents('php://input'), true);
+
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        // Try form data
+        $input = $_POST;
+    }
+
+    $action = $input['action'] ?? null;
+
+    if ($action !== 'mark_processed') {
+        errorResponse('Invalid action. Supported: mark_processed');
+    }
+
+    $feedbackId = (int)($input['feedback_id'] ?? 0);
+    $githubIssue = isset($input['github_issue']) ? (int)$input['github_issue'] : null;
+    $githubIssueUrl = $input['github_issue_url'] ?? null;
+
+    if ($feedbackId <= 0) {
+        errorResponse('feedback_id is required and must be a positive integer');
+    }
+
+    // Validate GitHub issue URL if provided
+    if ($githubIssueUrl && !filter_var($githubIssueUrl, FILTER_VALIDATE_URL)) {
+        errorResponse('Invalid github_issue_url format');
+    }
+
+    // Check if feedback exists
+    $checkStmt = $db->prepare("SELECT id FROM feedback WHERE id = ?");
+    $checkStmt->execute([$feedbackId]);
+    if (!$checkStmt->fetch()) {
+        errorResponse('Feedback not found', 404);
+    }
+
+    // Update the feedback
+    $stmt = $db->prepare("
+        UPDATE feedback
+        SET processed_at = NOW(),
+            github_issue = ?,
+            github_issue_url = ?,
+            status = CASE WHEN status = 'pending' THEN 'processing' ELSE status END
+        WHERE id = ?
+    ");
+    $stmt->execute([$githubIssue, $githubIssueUrl, $feedbackId]);
+
+    // Fetch updated record
+    $fetchStmt = $db->prepare("SELECT * FROM feedback WHERE id = ?");
+    $fetchStmt->execute([$feedbackId]);
+    $updated = $fetchStmt->fetch();
+    $updated['context'] = json_decode($updated['context'] ?? '{}', true);
+
+    jsonResponse([
+        'success' => true,
+        'message' => 'Feedback marked as processed',
+        'data' => $updated,
+    ]);
+}
+
+/**
+ * Handle PATCH requests - update feedback status
+ */
+function handlePatch(PDO $db, array $tokenData): void {
+    if (!hasPermission($tokenData, 'feedback:write')) {
+        errorResponse('Permission denied: feedback:write required', 403);
+    }
+
+    $input = json_decode(file_get_contents('php://input'), true);
+
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        errorResponse('Invalid JSON in request body');
+    }
+
+    $feedbackId = (int)($input['feedback_id'] ?? 0);
+    $status = $input['status'] ?? null;
+
+    if ($feedbackId <= 0) {
+        errorResponse('feedback_id is required and must be a positive integer');
+    }
+
+    $validStatuses = ['pending', 'processing', 'resolved', 'wontfix', 'duplicate', 'invalid'];
+    if (!$status || !in_array($status, $validStatuses)) {
+        errorResponse('Invalid status. Allowed: ' . implode(', ', $validStatuses));
+    }
+
+    // Check if feedback exists
+    $checkStmt = $db->prepare("SELECT id FROM feedback WHERE id = ?");
+    $checkStmt->execute([$feedbackId]);
+    if (!$checkStmt->fetch()) {
+        errorResponse('Feedback not found', 404);
+    }
+
+    // Build update query
+    $updates = ['status = ?'];
+    $params = [$status];
+
+    // Optional fields to update
+    if (isset($input['github_issue'])) {
+        $updates[] = 'github_issue = ?';
+        $params[] = (int)$input['github_issue'];
+    }
+
+    if (isset($input['github_issue_url'])) {
+        if ($input['github_issue_url'] && !filter_var($input['github_issue_url'], FILTER_VALIDATE_URL)) {
+            errorResponse('Invalid github_issue_url format');
+        }
+        $updates[] = 'github_issue_url = ?';
+        $params[] = $input['github_issue_url'];
+    }
+
+    $params[] = $feedbackId;
+
+    $sql = "UPDATE feedback SET " . implode(', ', $updates) . " WHERE id = ?";
+    $stmt = $db->prepare($sql);
+    $stmt->execute($params);
+
+    // Fetch updated record
+    $fetchStmt = $db->prepare("SELECT * FROM feedback WHERE id = ?");
+    $fetchStmt->execute([$feedbackId]);
+    $updated = $fetchStmt->fetch();
+    $updated['context'] = json_decode($updated['context'] ?? '{}', true);
+
+    jsonResponse([
+        'success' => true,
+        'message' => 'Feedback status updated',
+        'data' => $updated,
+    ]);
+}
+
+// Main execution
+try {
+    $db = getDbConnection();
+    $tokenData = authenticate($db);
+
+    switch ($_SERVER['REQUEST_METHOD']) {
+        case 'GET':
+            handleGet($db, $tokenData);
+            break;
+        case 'POST':
+            handlePost($db, $tokenData);
+            break;
+        case 'PATCH':
+            handlePatch($db, $tokenData);
+            break;
+        default:
+            errorResponse('Method not allowed', 405);
+    }
+} catch (PDOException $e) {
+    error_log("Database error: " . $e->getMessage());
+    errorResponse('Database error occurred', 500);
+} catch (Exception $e) {
+    error_log("Unexpected error: " . $e->getMessage());
+    errorResponse('An unexpected error occurred', 500);
+}

--- a/vandromeda-api/generate-token.php
+++ b/vandromeda-api/generate-token.php
@@ -1,0 +1,292 @@
+#!/usr/bin/env php
+<?php
+/**
+ * API Token Generator CLI Script
+ *
+ * Generates a new API token for authenticating with the feedback API.
+ *
+ * Usage:
+ *   php generate-token.php [options]
+ *
+ * Options:
+ *   --name=NAME           Token name/description (default: "CLI Generated Token")
+ *   --permissions=PERMS   Comma-separated permissions (default: "feedback:read,feedback:write,feedback:notify")
+ *   --expires=DAYS        Token expiration in days (default: no expiration)
+ *   --help                Show this help message
+ *
+ * Examples:
+ *   php generate-token.php
+ *   php generate-token.php --name="GitHub Actions" --permissions="feedback:read,feedback:write"
+ *   php generate-token.php --name="Admin Token" --permissions="*" --expires=365
+ */
+
+declare(strict_types=1);
+
+// Ensure CLI execution
+if (php_sapi_name() !== 'cli') {
+    die("This script must be run from the command line.\n");
+}
+
+// Load environment variables from .env file if it exists
+function loadEnv(string $path): void {
+    if (!file_exists($path)) {
+        return;
+    }
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        if (strpos(trim($line), '#') === 0) {
+            continue;
+        }
+        if (strpos($line, '=') !== false) {
+            list($name, $value) = explode('=', $line, 2);
+            $name = trim($name);
+            $value = trim($value, " \t\n\r\0\x0B\"'");
+            if (!getenv($name)) {
+                putenv("$name=$value");
+                $_ENV[$name] = $value;
+            }
+        }
+    }
+}
+
+loadEnv(__DIR__ . '/.env');
+
+/**
+ * Parse command line arguments
+ */
+function parseArgs(array $argv): array {
+    $options = [
+        'name' => 'CLI Generated Token',
+        'permissions' => 'feedback:read,feedback:write,feedback:notify',
+        'expires' => null,
+        'help' => false,
+    ];
+
+    foreach ($argv as $arg) {
+        if ($arg === '--help' || $arg === '-h') {
+            $options['help'] = true;
+        } elseif (preg_match('/^--name=(.+)$/', $arg, $m)) {
+            $options['name'] = $m[1];
+        } elseif (preg_match('/^--permissions=(.+)$/', $arg, $m)) {
+            $options['permissions'] = $m[1];
+        } elseif (preg_match('/^--expires=(\d+)$/', $arg, $m)) {
+            $options['expires'] = (int)$m[1];
+        }
+    }
+
+    return $options;
+}
+
+/**
+ * Show help message
+ */
+function showHelp(): void {
+    echo <<<HELP
+API Token Generator for Vandromeda Feedback API
+
+Usage:
+  php generate-token.php [options]
+
+Options:
+  --name=NAME           Token name/description
+                        Default: "CLI Generated Token"
+
+  --permissions=PERMS   Comma-separated list of permissions
+                        Available permissions:
+                          - feedback:read   (read feedback entries)
+                          - feedback:write  (update feedback entries)
+                          - feedback:notify (send notification emails)
+                          - *               (all permissions)
+                        Default: "feedback:read,feedback:write,feedback:notify"
+
+  --expires=DAYS        Token expiration in days from now
+                        Default: no expiration (never expires)
+
+  --help, -h            Show this help message
+
+Examples:
+  php generate-token.php
+    Generate a token with default settings
+
+  php generate-token.php --name="GitHub Actions"
+    Generate a token named "GitHub Actions"
+
+  php generate-token.php --permissions="feedback:read"
+    Generate a read-only token
+
+  php generate-token.php --name="Admin" --permissions="*" --expires=365
+    Generate an admin token that expires in 1 year
+
+Environment Variables:
+  The script reads database credentials from .env file or environment:
+    DB_HOST     Database host (default: localhost)
+    DB_PORT     Database port (default: 3306)
+    DB_NAME     Database name (default: vandromeda)
+    DB_USER     Database username (default: root)
+    DB_PASS     Database password (default: empty)
+
+
+HELP;
+}
+
+/**
+ * Generate a cryptographically secure random token
+ */
+function generateSecureToken(int $length = 64): string {
+    // Generate random bytes
+    $bytes = random_bytes($length / 2);
+    return bin2hex($bytes);
+}
+
+/**
+ * Get database connection
+ */
+function getDbConnection(): PDO {
+    $host = getenv('DB_HOST') ?: 'localhost';
+    $port = getenv('DB_PORT') ?: '3306';
+    $dbname = getenv('DB_NAME') ?: 'vandromeda';
+    $username = getenv('DB_USER') ?: 'root';
+    $password = getenv('DB_PASS') ?: '';
+
+    $dsn = "mysql:host=$host;port=$port;dbname=$dbname;charset=utf8mb4";
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ];
+
+    return new PDO($dsn, $username, $password, $options);
+}
+
+/**
+ * Format output with colors for terminal
+ */
+function colorize(string $text, string $color): string {
+    $colors = [
+        'green' => "\033[32m",
+        'red' => "\033[31m",
+        'yellow' => "\033[33m",
+        'blue' => "\033[34m",
+        'cyan' => "\033[36m",
+        'reset' => "\033[0m",
+        'bold' => "\033[1m",
+    ];
+
+    // Check if terminal supports colors
+    if (!stream_isatty(STDOUT)) {
+        return $text;
+    }
+
+    return ($colors[$color] ?? '') . $text . $colors['reset'];
+}
+
+// Main execution
+try {
+    $options = parseArgs($argv);
+
+    if ($options['help']) {
+        showHelp();
+        exit(0);
+    }
+
+    echo colorize("\n=== Vandromeda API Token Generator ===\n\n", 'bold');
+
+    // Validate permissions
+    $permissions = array_map('trim', explode(',', $options['permissions']));
+    $validPermissions = ['feedback:read', 'feedback:write', 'feedback:notify', '*'];
+
+    foreach ($permissions as $perm) {
+        if (!in_array($perm, $validPermissions)) {
+            echo colorize("Error: ", 'red') . "Invalid permission: $perm\n";
+            echo "Valid permissions: " . implode(', ', $validPermissions) . "\n";
+            exit(1);
+        }
+    }
+
+    // Connect to database
+    echo "Connecting to database... ";
+    try {
+        $db = getDbConnection();
+        echo colorize("OK\n", 'green');
+    } catch (PDOException $e) {
+        echo colorize("FAILED\n", 'red');
+        echo colorize("Error: ", 'red') . $e->getMessage() . "\n\n";
+        echo "Please ensure your .env file contains valid database credentials:\n";
+        echo "  DB_HOST=localhost\n";
+        echo "  DB_PORT=3306\n";
+        echo "  DB_NAME=vandromeda\n";
+        echo "  DB_USER=your_username\n";
+        echo "  DB_PASS=your_password\n";
+        exit(1);
+    }
+
+    // Generate secure token
+    echo "Generating secure token... ";
+    $token = generateSecureToken(64);
+    echo colorize("OK\n", 'green');
+
+    // Calculate expiration
+    $expiresAt = null;
+    if ($options['expires'] !== null && $options['expires'] > 0) {
+        $expiresAt = date('Y-m-d H:i:s', strtotime("+{$options['expires']} days"));
+    }
+
+    // Insert token into database
+    echo "Saving to database... ";
+    try {
+        $stmt = $db->prepare("
+            INSERT INTO api_tokens (token, name, permissions, expires_at, created_at)
+            VALUES (?, ?, ?, ?, NOW())
+        ");
+        $stmt->execute([
+            $token,
+            $options['name'],
+            json_encode($permissions),
+            $expiresAt,
+        ]);
+        $tokenId = $db->lastInsertId();
+        echo colorize("OK\n", 'green');
+    } catch (PDOException $e) {
+        echo colorize("FAILED\n", 'red');
+        echo colorize("Error: ", 'red') . $e->getMessage() . "\n";
+
+        if (strpos($e->getMessage(), "doesn't exist") !== false) {
+            echo "\nThe api_tokens table does not exist. Run the following SQL to create it:\n\n";
+            echo colorize("CREATE TABLE api_tokens (\n", 'cyan');
+            echo colorize("    id INT AUTO_INCREMENT PRIMARY KEY,\n", 'cyan');
+            echo colorize("    token VARCHAR(64) UNIQUE,\n", 'cyan');
+            echo colorize("    name VARCHAR(100),\n", 'cyan');
+            echo colorize("    permissions JSON,\n", 'cyan');
+            echo colorize("    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,\n", 'cyan');
+            echo colorize("    expires_at DATETIME\n", 'cyan');
+            echo colorize(");\n", 'cyan');
+        }
+        exit(1);
+    }
+
+    // Display results
+    echo "\n" . colorize("Token created successfully!\n", 'green');
+    echo str_repeat('-', 60) . "\n\n";
+
+    echo colorize("Token ID:     ", 'bold') . $tokenId . "\n";
+    echo colorize("Name:         ", 'bold') . $options['name'] . "\n";
+    echo colorize("Permissions:  ", 'bold') . implode(', ', $permissions) . "\n";
+    echo colorize("Expires:      ", 'bold') . ($expiresAt ?? 'Never') . "\n";
+
+    echo "\n" . colorize("Your API Token:\n", 'bold');
+    echo colorize($token, 'cyan') . "\n";
+
+    echo "\n" . str_repeat('-', 60) . "\n";
+    echo colorize("IMPORTANT: ", 'yellow') . "Save this token securely. It will not be shown again.\n\n";
+
+    echo colorize("Usage Example:\n", 'bold');
+    echo "curl -H \"Authorization: Bearer $token\" \\\n";
+    echo "     https://your-domain.com/feedback.php?product=quizmyself&unprocessed=true\n\n";
+
+    echo colorize("Environment Variable:\n", 'bold');
+    echo "export VANDROMEDA_API_TOKEN=\"$token\"\n\n";
+
+} catch (Exception $e) {
+    echo colorize("\nFatal Error: ", 'red') . $e->getMessage() . "\n";
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- Display feedback ID (#X) after submitting feedback
- Show feedback ID and GitHub issue link (GH-X) in roadmap items
- Extract feedback_id from issue body in roadmap workflow
- Add vandromeda-api reference files

## Server-Side Requirement
The Vandromeda feedback.php endpoint needs to return `feedback_id` in the response when new feedback is submitted:
```json
{
  "success": true,
  "feedback_id": 123
}
```

## Test Plan
- [ ] Submit feedback, verify ID is shown
- [ ] Open roadmap, verify issue numbers are displayed
- [ ] Verify GitHub links work

Generated with Claude Code