### PR TITLE
feat: add Plausible analytics for usage tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2 - 2026-01-18
+- Feature: Add Plausible analytics for usage tracking
+- Track quiz starts, imports, AI generations, and upgrade clicks
+
 ## 0.1.1 - 2026-01-18
 - Security: Escape user input in onclick handlers to prevent XSS
 - Fixed keyword and category buttons vulnerable to injection attacks

--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
     <meta name="deployed-sha" content="__COMMIT_SHA__">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📝</text></svg>">
     <title>QuizMyself - Quiz Yourself on Anything</title>
+    <!-- Plausible Analytics - privacy-friendly, no cookies -->
+    <script defer data-domain="fullstackkevinvandriel.github.io" src="https://plausible.io/js/script.js"></script>
+    <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
     <style>
         * {
             margin: 0;
@@ -3332,9 +3335,11 @@
 
         const VANDROMEDA_API = 'https://www.vandromeda.com/api';
         const FREE_IMPORT_LIMIT = 50;
+        // TODO: Replace with LIVE Stripe price IDs before launch
+        // Current: TEST mode prices - Create live products in Stripe Dashboard first
         const STRIPE_PRICES = {
-            monthly: 'price_1SosTEE0LClU4PH9magrG0Bo',
-            yearly: 'price_1SosUDE0LClU4PH9ycCWqpQ5'
+            monthly: 'price_1SosTEE0LClU4PH9magrG0Bo',  // TODO: Replace with live price ID
+            yearly: 'price_1SosUDE0LClU4PH9ycCWqpQ5'   // TODO: Replace with live price ID
         };
         let currentKeyword = '';
 
@@ -5156,6 +5161,7 @@
                 showToast('No questions available. Select at least one category or import some questions!', 'warning');
                 return;
             }
+            plausible('Quiz Start', { props: { mode: 'practice', questions: filteredQuestions.length } });
             state.currentMode = 'practice';
             showScreen('quiz-screen');
             loadNextQuestion();
@@ -6410,6 +6416,8 @@
             updateStats();
             saveState(true);
 
+            plausible('Import', { props: { count: importCount, mode: replaceMode ? 'replace' : 'append' } });
+
             // Reset the form
             document.getElementById('import-textarea-modal').value = '';
             document.getElementById('import-preview-section-modal').style.display = 'none';
@@ -6856,6 +6864,7 @@
                 aiGenerationState.questions = data.questions;
                 aiGenerationState.usage = data.usage;
                 updateUsageDisplay(data.usage);
+                plausible('AI Generate', { props: { questions: data.questions.length, difficulty: difficulty } });
                 showQuestionPreview();
 
             } catch (err) {
@@ -7275,6 +7284,7 @@
         }
 
         function showUpgradeModal(options = {}) {
+            plausible('Upgrade Click');
             document.getElementById('upgrade-modal').classList.remove('hidden');
             document.body.style.overflow = 'hidden';
             document.getElementById('upgrade-error').style.display = 'none';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quizmyself",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Self-study quiz tool with custom content imports",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- Add Plausible analytics script (privacy-friendly, no cookies, GDPR compliant)
- Track key user actions with custom events

## Events Tracked
| Event | Properties |
|-------|------------|
| Quiz Start | mode, questions count |
| Import | count, mode (replace/append) |
| AI Generate | questions count, difficulty |
| Upgrade Click | — |

## Setup Required
1. Create Plausible account at plausible.io
2. Add site: `fullstackkevinvandriel.github.io`
3. Events will start appearing in dashboard

## Test plan
- [x] Script loads without errors
- [x] Events fire on user actions (check browser console)
- [x] No cookies set (privacy check)

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)