### PR TITLE
fix: clear source state when switching keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.3 - 2026-01-18
+- Fix: Clear source state when switching keywords to prevent cross-quiz contamination
+
 ## 0.1.2 - 2026-01-18
 - Feature: Add Plausible analytics for usage tracking
 - Track quiz starts, imports, AI generations, and upgrade clicks

--- a/index.html
+++ b/index.html
@@ -3976,6 +3976,13 @@
             currentKeyword = keyword;
             localStorage.setItem('quizmyself_active_keyword', keyword);
 
+            // Clear source viewing state to prevent cross-keyword contamination
+            currentViewingSourceId = null;
+            if (typeof aiGenerationState !== 'undefined') {
+                aiGenerationState.sourceId = null;
+                aiGenerationState.sourceName = null;
+            }
+
             // Load progress for this keyword
             await loadState();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quizmyself",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Self-study quiz tool with custom content imports",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- Clear `currentViewingSourceId` and `aiGenerationState` when switching keywords
- Prevents quiz generation from incorrectly linking to source material from previous keyword

## Problem
When a user:
1. Views source material on keyword A (sets `currentViewingSourceId = X`)
2. Switches to keyword B
3. Generates a quiz

The quiz would incorrectly link to source X from keyword A.

## Solution
Reset source state variables in `selectKeyword()` before loading the new keyword's data.

## Test plan
- [x] Switch keywords and verify source state is cleared
- [x] Generate quiz on new keyword without viewing source first → should error "No source selected"

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)