### PR TITLE
fix: add source reference to AI-generated questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.4 - 2026-01-18
+- Fix: Add source reference to AI-generated questions so "View in Source" button works
+
 ## 0.1.3 - 2026-01-18
 - Fix: Clear source state when switching keywords to prevent cross-quiz contamination
 

--- a/index.html
+++ b/index.html
@@ -7522,6 +7522,9 @@
             generatedQuestions.forEach((q, idx) => {
                 q.id = startId + idx;
                 q.category = 'AI Generated';
+                // Add source reference so "View in Source" button works
+                q.sourceId = aiGenerationState.sourceId;
+                q.sourceName = aiGenerationState.sourceName;
                 questions.push(q);
             });
 
@@ -7767,6 +7770,9 @@
             generatedQuestions.forEach((q, idx) => {
                 q.id = startId + idx;
                 q.category = 'AI Generated';
+                // Add source reference so "View in Source" button works
+                q.sourceId = aiGenerationState.sourceId;
+                q.sourceName = aiGenerationState.sourceName;
                 questions.push(q);
             });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quizmyself",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Self-study quiz tool with custom content imports",
   "private": true,
   "scripts": {
@@ -8,7 +8,10 @@
     "version:check": "node tools/version-check.mjs",
     "test": "playwright test",
     "test:headed": "playwright test --headed",
-    "test:ui": "playwright test --ui"
+    "test:ui": "playwright test --ui",
+    "beta:guide": "node scripts/generate-beta-testing-guide.js",
+    "beta:email": "node scripts/generate-beta-email.js",
+    "beta:preview": "node scripts/generate-beta-email.js --preview"
   },
   "devDependencies": {
     "@playwright/test": "^1.40.0",


### PR DESCRIPTION
## Summary
- Add `sourceId` and `sourceName` to AI-generated questions when accepting them
- Enables "View in Source" button after wrong answers

## Problem
When users generated questions from source material and got an answer wrong:
1. "View in Source" button wouldn't appear
2. Clicking "Study Material" showed: "No study material available for this category: AI Generated"

## Solution
In both `acceptCoverageQuestions()` and `acceptGeneratedQuestions()`, add:
```javascript
q.sourceId = aiGenerationState.sourceId;
q.sourceName = aiGenerationState.sourceName;
```

## Test plan
- [x] Generate quiz from source material
- [x] Answer question wrong
- [x] "View in Source" button should appear
- [x] Clicking it opens the source material

Fixes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)