### PR TITLE
Fix P0 XSS vulnerabilities in onclick handlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -5041,7 +5041,7 @@
             list.innerHTML = userKeywords.map(kw => `
                 <div class="keyword-item">
                     <div class="keyword-item-info">
-                        <div class="keyword-item-name ${currentKeyword === kw.keyword ? 'active' : ''}">${kw.keyword}</div>
+                        <div class="keyword-item-name ${currentKeyword === kw.keyword ? 'active' : ''}">${escapeHtml(kw.keyword)}</div>
                         <div class="keyword-item-date">
                             ${kw.question_count > 0 ? `<span style="color: #4fc3f7;">${kw.question_count} questions</span>` : '<span style="color: #666;">No questions</span>'}
                             ${kw.source_count > 0 ? ` | <span style="color: #888;">${kw.source_count} source${kw.source_count > 1 ? 's' : ''}</span>` : ''}
@@ -5050,9 +5050,9 @@
                     </div>
                     <div class="keyword-item-actions">
                         ${currentKeyword !== kw.keyword ?
-                            `<button class="btn btn-small btn-primary" onclick="selectKeyword('${escapeJsString(kw.keyword)}'); renderKeywordList();">Use</button>` :
+                            `<button class="btn btn-small btn-primary" data-action="select-keyword" data-keyword="${escapeAttr(kw.keyword)}">Use</button>` :
                             '<span style="color: #4fc3f7; font-size: 0.8rem; padding: 5px 10px;">Active</span>'}
-                        <button class="btn btn-small btn-danger" onclick="confirmDeleteKeyword('${escapeJsString(kw.keyword)}')">Delete</button>
+                        <button class="btn btn-small btn-danger" data-action="delete-keyword" data-keyword="${escapeAttr(kw.keyword)}">Delete</button>
                     </div>
                 </div>
             `).join('');
@@ -5238,6 +5238,67 @@
             }
         });
 
+        // Event delegation for dynamically created elements (XSS-safe)
+        document.addEventListener('click', function(e) {
+            const target = e.target.closest('[data-action]');
+            if (!target) return;
+
+            const action = target.dataset.action;
+            const keyword = target.dataset.keyword;
+            const category = target.dataset.category;
+            const sourceId = target.dataset.sourceId;
+            const sourceName = target.dataset.sourceName;
+            const contentType = target.dataset.contentType;
+
+            switch (action) {
+                case 'select-keyword':
+                    if (keyword) {
+                        selectKeyword(keyword);
+                        renderKeywordList();
+                    }
+                    break;
+                case 'delete-keyword':
+                    if (keyword) {
+                        confirmDeleteKeyword(keyword);
+                    }
+                    break;
+                case 'toggle-category':
+                    if (category) {
+                        toggleCategory(category);
+                    }
+                    break;
+                case 'toggle-welcome-category':
+                    if (category) {
+                        toggleWelcomeCategory(target, category);
+                    }
+                    break;
+                case 'link-source':
+                    if (sourceId && sourceName) {
+                        linkSourceToQuiz(parseInt(sourceId), sourceName);
+                    }
+                    break;
+                case 'unlink-source':
+                    if (keyword) {
+                        unlinkSourceFromQuiz(keyword);
+                    }
+                    break;
+                case 'view-source':
+                    if (sourceId && sourceName && contentType) {
+                        viewSourceContent(parseInt(sourceId), sourceName, contentType);
+                    }
+                    break;
+                case 'delete-source':
+                    if (sourceId && sourceName) {
+                        deleteSource(parseInt(sourceId), sourceName);
+                    }
+                    break;
+                case 'filter-course-content':
+                    // Empty string means null (show all)
+                    filterCourseContent(category || null);
+                    break;
+            }
+        });
+
         // Load state from server
         async function loadState() {
             if (!currentKeyword) return;
@@ -5395,7 +5456,7 @@
                 const isActive = selectedCategories.has(cat);
                 const count = questions.filter(q => q.category === cat).length;
                 return `<button class="category-chip ${isActive ? 'active' : ''}"
-                    onclick="toggleCategory('${escapeJsString(cat)}')">${escapeHtml(cat)} (${count})</button>`;
+                    data-action="toggle-category" data-category="${escapeAttr(cat)}">${escapeHtml(cat)} (${count})</button>`;
             }).join('');
         }
 
@@ -5450,12 +5511,12 @@
             const showAll = courseContentCategory === null;
 
             container.innerHTML = `<button class="category-chip ${showAll ? 'active' : ''}"
-                onclick="filterCourseContent(null)">All</button>` +
+                data-action="filter-course-content" data-category="">All</button>` +
                 allCategories.map(cat => {
                     const isActive = courseContentCategory === cat;
                     const count = questions.filter(q => q.category === cat).length;
                     return `<button class="category-chip ${isActive ? 'active' : ''}"
-                        onclick="filterCourseContent('${escapeJsString(cat)}')">${escapeHtml(cat)} (${count})</button>`;
+                        data-action="filter-course-content" data-category="${escapeAttr(cat)}">${escapeHtml(cat)} (${count})</button>`;
                 }).join('');
         }
 
@@ -6860,10 +6921,10 @@
                             </div>
                         </div>
                         <div style="display: flex; gap: 8px; flex-shrink: 0;">
-                            ${!source.linkedKeyword ? `<button class="btn btn-small btn-success" onclick="linkSourceToQuiz(${source.id}, '${escapeJsString(source.name)}')">Link</button>` : ''}
-                            ${source.linkedKeyword ? `<button class="btn btn-small" style="background: #555;" onclick="unlinkSourceFromQuiz('${escapeJsString(source.linkedKeyword)}')">Unlink</button>` : ''}
-                            <button class="btn btn-small" onclick="viewSourceContent(${source.id}, '${escapeJsString(source.name)}', '${escapeJsString(source.contentType || 'text/plain')}')">View</button>
-                            <button class="btn btn-danger btn-small" onclick="deleteSource(${source.id}, '${escapeJsString(source.name)}')">Delete</button>
+                            ${!source.linkedKeyword ? `<button class="btn btn-small btn-success" data-action="link-source" data-source-id="${source.id}" data-source-name="${escapeAttr(source.name)}">Link</button>` : ''}
+                            ${source.linkedKeyword ? `<button class="btn btn-small" style="background: #555;" data-action="unlink-source" data-keyword="${escapeAttr(source.linkedKeyword)}">Unlink</button>` : ''}
+                            <button class="btn btn-small" data-action="view-source" data-source-id="${source.id}" data-source-name="${escapeAttr(source.name)}" data-content-type="${escapeAttr(source.contentType || 'text/plain')}">View</button>
+                            <button class="btn btn-danger btn-small" data-action="delete-source" data-source-id="${source.id}" data-source-name="${escapeAttr(source.name)}">Delete</button>
                         </div>
                     </div>
                 `}).join('');
@@ -8436,7 +8497,7 @@
             const categories = [...new Set(demoQuestions.map(q => q.category))];
 
             container.innerHTML = categories.map(cat =>
-                `<button class="welcome-category-chip selected" onclick="toggleWelcomeCategory(this, '${escapeJsString(cat)}')">${escapeHtml(cat)}</button>`
+                `<button class="welcome-category-chip selected" data-action="toggle-welcome-category" data-category="${escapeAttr(cat)}">${escapeHtml(cat)}</button>`
             ).join('');
 
             // Start with all selected
@@ -8444,7 +8505,7 @@
         }
 
         function toggleWelcomeCategory(btn, category) {
-            btn.classList.toggle('selected');
+            if (btn) btn.classList.toggle('selected');
             if (welcomeSelectedCategories.has(category)) {
                 welcomeSelectedCategories.delete(category);
             } else {


### PR DESCRIPTION
## Summary
- Replace inline onclick handlers with data-* attributes and event delegation
- Affects keyword, category, source management, and welcome screen buttons
- Prevents XSS attacks from malicious quiz imports containing JavaScript in category names or keywords

## Changes
- Keyword list buttons: `data-action="select-keyword/delete-keyword"`
- Category chip buttons: `data-action="toggle-category"`
- Course content filter: `data-action="filter-course-content"`
- Source management: `data-action="link/unlink/view/delete-source"`
- Welcome categories: `data-action="toggle-welcome-category"`
- Added centralized event delegation listener

## Test plan
- [x] All Playwright tests pass
- [x] Category filter tests pass specifically

🤖 Generated with [Claude Code](https://claude.com/claude-code)