### PR TITLE
feat: reconcile GitHub issues on Progress modal open

### DIFF
--- a/index.html
+++ b/index.html
@@ -5991,8 +5991,8 @@
                 fetchUserStarredItems();
             }
 
-            // Fetch live feedback from Vandromeda API
-            fetch(`${VANDROMEDA_API}/feedback.php?product=quizmyself&public=true`)
+            // Fetch and reconcile feedback from Vandromeda API (syncs with GitHub)
+            fetch(`${VANDROMEDA_API}/quizmyself/reconcile-feedback.php?product=quizmyself`)
                 .then(response => {
                     if (!response.ok) throw new Error('Failed to load roadmap');
                     return response.json();


### PR DESCRIPTION
## Summary

- Progress modal now calls `/api/quizmyself/reconcile-feedback.php` instead of `/api/feedback.php`
- On every modal open, the API:
  - Fetches all GitHub issues
  - Syncs status from GitHub → DB (GitHub is king)
  - Creates feedback entries for any new GitHub issues
  - Detects orphaned entries (in DB but not GitHub)
  - Returns fully reconciled data

This ensures the Progress modal always shows current GitHub state.

## Test plan

- [ ] Open Progress modal
- [ ] Verify reconciliation stats in network response
- [ ] Close an issue on GitHub, reopen modal, verify status updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)