### PR TITLE
a11y: extend reduced motion support to all animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -3559,11 +3559,62 @@
                 animation: none;
             }
 
+            /* Disable spinner animation - show static indicator instead */
+            .spinner {
+                animation: none;
+                border-top-color: #4fc3f7;
+                opacity: 0.7;
+            }
+
+            /* Disable skeleton loading animations */
+            .skeleton-item {
+                animation: none;
+            }
+
+            .skeleton-title,
+            .skeleton-badge,
+            .skeleton-content,
+            .skeleton-progress {
+                animation: none;
+                background: #2a2a4e;
+            }
+
+            /* Disable toast slide animations - show instantly */
+            .toast {
+                animation: none;
+            }
+
+            .toast.hiding {
+                animation: none;
+                opacity: 0;
+            }
+
+            /* Disable all non-essential transitions */
             .theme-card,
             .roadmap-item,
             .item-progress-fill,
-            .theme-progress-fill {
-                transition: none;
+            .theme-progress-fill,
+            .progress-view-btn,
+            .progress-filter-chip,
+            .automation-toggle-slider,
+            .automation-toggle-slider:before,
+            .skip-link,
+            .milestone-progress-circle,
+            .toast-close,
+            .feature-signin-prompt a,
+            button,
+            a,
+            input,
+            select {
+                transition: none !important;
+            }
+
+            /* Preserve essential visual feedback without animation */
+            .progress-bar-fill,
+            .item-progress-fill,
+            .theme-progress-fill,
+            #sources-storage-bar {
+                transition: none !important;
             }
         }
 


### PR DESCRIPTION
## Summary
- Comprehensive reduced motion support for WCAG 2.3.3 (Animation from Interactions) Level AAA compliance
- Disables spinner, skeleton loading, toast slide, and button/link transition animations when user prefers reduced motion
- Preserves all functionality while reducing vestibular motion triggers

## Changes
- Disable spinner animation (show static loading indicator)
- Disable skeleton loading shimmer and pulse animations
- Disable toast slide-in/out animations (show/hide instantly)
- Disable non-essential transitions on interactive elements (buttons, links, inputs, toggle sliders)
- Preserve essential visual feedback without animation

## Test plan
- [ ] Enable "Reduce motion" in system accessibility settings
- [ ] Verify spinner shows as static indicator (not spinning)
- [ ] Verify skeleton loading shows solid color (no shimmer effect)
- [ ] Verify toasts appear/disappear instantly (no slide animation)
- [ ] Verify buttons/links/inputs work correctly without transition effects
- [ ] Verify all existing tests pass

Closes #219

---
Generated with [Claude Code](https://claude.com/claude-code)