### PR TITLE
a11y: fix skip link implementation for WCAG 2.4.1 compliance

### DIFF
--- a/index.html
+++ b/index.html
@@ -3833,6 +3833,9 @@
     <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-auth-compat.js"></script>
 </head>
 <body>
+    <!-- Skip Link for Accessibility (WCAG 2.4.1 Bypass Blocks) -->
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+
     <!-- Toast Container -->
     <div id="toast-container" class="toast-container"></div>
 
@@ -3970,7 +3973,7 @@
         </div>
     </div>
 
-    <div class="container">
+    <main id="main-content" class="container" role="main" tabindex="-1">
         <header>
             <h1>QuizMyself</h1>
             <p class="subtitle">Quiz Yourself on Anything</p>
@@ -4126,7 +4129,7 @@
                 <div id="course-content-list"></div>
             </div>
         </div>
-    </div>
+    </main>
 
     <!-- Study Material Modal -->
     <div id="study-modal" class="modal-overlay hidden" onclick="closeModalOnOverlay(event)">
@@ -4835,12 +4838,11 @@
     <!-- Roadmap Modal -->
     <div id="roadmap-modal" class="modal-overlay hidden" onclick="closeRoadmapModalOnOverlay(event)" role="dialog" aria-modal="true" aria-labelledby="roadmap-modal-title">
         <div class="modal-content" onclick="event.stopPropagation()" style="max-width: 600px;">
-            <a href="#roadmap-main-content" class="skip-link">Skip to main content</a>
             <div class="modal-header">
                 <h2 id="roadmap-modal-title">Progress</h2>
                 <button class="modal-close" onclick="closeRoadmapModal()" aria-label="Close progress modal">&times;</button>
             </div>
-            <div class="modal-body" id="roadmap-content" role="main" id="roadmap-main-content">
+            <div class="modal-body" id="roadmap-content">
                 <!-- Dynamic content loaded here -->
             </div>
         </div>

--- a/tests/skip-link.spec.js
+++ b/tests/skip-link.spec.js
@@ -1,0 +1,83 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+test.describe("Skip Link Accessibility (WCAG 2.4.1)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    const skipIntro = page.locator('button:has-text("Skip intro")');
+    if (await skipIntro.isVisible()) await skipIntro.click();
+  });
+
+  test("skip link is first focusable element after body", async ({ page }) => {
+    // Get all focusable elements in the page
+    const firstFocusable = await page.evaluate(() => {
+      const focusable = document.querySelectorAll(
+        'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      // Filter to only visible/non-hidden elements
+      for (const el of focusable) {
+        const style = window.getComputedStyle(el);
+        const parent = el.closest(".hidden, [hidden]");
+        if (
+          !parent &&
+          style.display !== "none" &&
+          style.visibility !== "hidden"
+        ) {
+          return el.className;
+        }
+      }
+      return null;
+    });
+    expect(firstFocusable).toBe("skip-link");
+  });
+
+  test("skip link has CSS for visibility on focus", async ({ page }) => {
+    const skipLink = page.locator(".skip-link");
+    // Check that skip link starts positioned off-screen
+    const initialTop = await skipLink.evaluate((el) =>
+      parseInt(window.getComputedStyle(el).top),
+    );
+    expect(initialTop).toBeLessThan(0);
+
+    // Focus the skip link and wait for the style to apply
+    await skipLink.focus();
+    await page.waitForTimeout(350); // Wait for transition (0.3s)
+
+    // Check that skip link is now visible (top: 0)
+    const focusedTop = await skipLink.evaluate((el) =>
+      parseInt(window.getComputedStyle(el).top),
+    );
+    expect(focusedTop).toBe(0);
+  });
+
+  test("skip link targets main content", async ({ page }) => {
+    expect(await page.locator(".skip-link").getAttribute("href")).toBe(
+      "#main-content",
+    );
+  });
+
+  test("main content element exists", async ({ page }) => {
+    await expect(page.locator("#main-content")).toBeAttached();
+  });
+
+  test("skip link navigates to main on click", async ({ page }) => {
+    const skipLink = page.locator(".skip-link");
+    await skipLink.focus();
+    await skipLink.click();
+    await expect(page.locator("#main-content")).toBeFocused();
+  });
+
+  test("main content has ARIA role", async ({ page }) => {
+    expect(await page.locator("#main-content").getAttribute("role")).toBe(
+      "main",
+    );
+  });
+
+  test("page has only one skip link", async ({ page }) => {
+    await expect(page.locator(".skip-link")).toHaveCount(1);
+  });
+
+  test("no skip link in roadmap modal", async ({ page }) => {
+    await expect(page.locator("#roadmap-modal .skip-link")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add skip link as first focusable element after body tag (WCAG 2.4.1 requirement)
- Convert main container from div to semantic main element with proper ARIA attributes
- Remove incorrectly placed skip link from roadmap modal
- Fix duplicate id attribute in roadmap modal body
- Add comprehensive Playwright tests for skip link functionality (8 tests)

## Test plan
- [x] Skip link is the first focusable element on the page
- [x] Skip link becomes visible when focused
- [x] Skip link correctly targets main content area
- [x] Main content element exists with proper ARIA role
- [x] Skip link navigates to main content on click
- [x] Page has only one skip link
- [x] No skip link exists in roadmap modal

Fixes #217

Generated with [Claude Code](https://claude.com/claude-code)