### PR TITLE
Fix Link button in Quiz Data modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -9102,7 +9102,7 @@
         });
 
         // Event delegation for dynamically created elements (XSS-safe)
-        document.addEventListener('click', function(e) {
+        function handleDataAction(e) {
             const target = e.target.closest('[data-action]');
             if (!target) return;
 
@@ -9160,7 +9160,12 @@
                     filterCourseContent(category || null);
                     break;
             }
-        });
+        }
+
+        document.addEventListener('click', handleDataAction);
+
+        // Also handle clicks inside modals with stopPropagation (sources-modal, etc.)
+        document.getElementById('sources-modal').addEventListener('click', handleDataAction);
 
         // Load state from server
         async function loadState() {


### PR DESCRIPTION
## Summary
- Fixed Link button not responding to clicks in the Quiz Data modal
- The modal-content div has `stopPropagation()` which blocked document-level event delegation
- Solution: Add event listener directly on sources-modal element

## Test plan
- [ ] Open Quiz Data modal with an unlinked source
- [ ] Click the green "Link" button
- [ ] Verify selection modal appears with available quizzes

🤖 Generated with [Claude Code](https://claude.com/claude-code)