### PR TITLE
Fix Quiz Data modal buttons (Link/View/Delete)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9164,8 +9164,8 @@
 
         document.addEventListener('click', handleDataAction);
 
-        // Also handle clicks inside modals with stopPropagation (sources-modal, etc.)
-        document.getElementById('sources-modal').addEventListener('click', handleDataAction);
+        // Handle clicks inside sources-list (inside modal-content which has stopPropagation)
+        document.getElementById('sources-list').addEventListener('click', handleDataAction);
 
         // Load state from server
         async function loadState() {


### PR DESCRIPTION
## Summary
- Fixed Link, View, and Delete buttons not responding in Quiz Data modal
- Previous fix incorrectly placed listener on sources-modal (overlay)
- The modal-content has stopPropagation which blocks events before reaching the overlay
- Correct fix: Add listener to sources-list which is INSIDE modal-content

## Root cause
```
sources-modal (overlay) ← listener here never sees events
  └─ modal-content ← onclick="event.stopPropagation()" blocks here
       └─ sources-list ← listener should be here ✓
            └─ buttons with data-action
```

## Test plan
- [ ] Open Quiz Data modal
- [ ] Click Link button on unlinked source → should show quiz selection
- [ ] Click View button → should show source content
- [ ] Click Delete button → should show confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)